### PR TITLE
Fix product query in market route

### DIFF
--- a/CRUNEVO/crunevo/routes/market_routes.py
+++ b/CRUNEVO/crunevo/routes/market_routes.py
@@ -5,7 +5,9 @@ market_bp = Blueprint('market', __name__, url_prefix='/marketplace')
 
 @market_bp.route('/')
 def market_home():
-    productos = Product.query.filter_by(aprobado=True).all()
+    # Retrieve all products without filtering by an "aprobado" field, since
+    # that attribute does not exist in the Product model.
+    productos = Product.query.all()
     return render_template('marketplace/market.html', productos=productos)
 
 @market_bp.route('/producto/<int:id>')


### PR DESCRIPTION
## Summary
- remove nonexistent `aprobado` filter when listing products

## Testing
- `python3 -m compileall crunevo`

------
https://chatgpt.com/codex/tasks/task_e_68424586a8508325b13539b3b6318c2a