### PR TITLE
Add pytest and basic app test

### DIFF
--- a/CRUNEVO/requirements.txt
+++ b/CRUNEVO/requirements.txt
@@ -4,3 +4,4 @@ Flask-SQLAlchemy==3.1.1
 SQLAlchemy==2.0.40
 python-dotenv==1.1.0
 Flask-Login==0.6.3
+pytest==8.1.1

--- a/CRUNEVO/tests/test_app.py
+++ b/CRUNEVO/tests/test_app.py
@@ -1,0 +1,12 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from crunevo.app import create_app
+
+def test_index_route():
+    app = create_app()
+    with app.test_client() as client:
+        response = client.get('/')
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary
- add pytest as a dependency
- create tests directory with a basic test for the root route

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842458c9e1c832589f7e2ccee17e695