### PR TITLE
Fix auth blueprint registration

### DIFF
--- a/CRUNEVO/crunevo/__init__.py
+++ b/CRUNEVO/crunevo/__init__.py
@@ -2,6 +2,7 @@
 from flask import Flask
 from .models import db
 from .routes.main_routes import main_bp
+from .routes.auth_routes import auth_bp
 
 def create_app():
     app = Flask(__name__)
@@ -9,5 +10,6 @@ def create_app():
 
     db.init_app(app)
     app.register_blueprint(main_bp)
+    app.register_blueprint(auth_bp)
 
     return app


### PR DESCRIPTION
## Summary
- register `auth_bp` so templates referencing auth routes work

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68424a55491c8325a2c28307f88c3c02