### PR TITLE
Enable store and notes sections

### DIFF
--- a/CRUNEVO/crunevo/__init__.py
+++ b/CRUNEVO/crunevo/__init__.py
@@ -8,6 +8,8 @@ from .models.product import Product
 from .models.forum import Pregunta, Respuesta
 from .routes.main_routes import main_bp
 from .routes.auth_routes import auth_bp
+from .routes.store_routes import store_bp
+from .routes.note_routes import note_bp
 
 login_manager = LoginManager()
 login_manager.login_view = "auth.login"
@@ -28,5 +30,7 @@ def create_app():
 
     app.register_blueprint(main_bp)
     app.register_blueprint(auth_bp)
+    app.register_blueprint(store_bp)
+    app.register_blueprint(note_bp)
 
     return app

--- a/CRUNEVO/crunevo/routes/note_routes.py
+++ b/CRUNEVO/crunevo/routes/note_routes.py
@@ -5,9 +5,9 @@ import os
 import boto3
 from botocore.exceptions import NoCredentialsError, ClientError
 
-from src.models import db
-from src.models.note import Note
-from src.models.user import User
+from ..models import db
+from ..models.note import Note
+from ..models.user import User
 
 note_bp = Blueprint("note", __name__)
 

--- a/CRUNEVO/crunevo/routes/store_routes.py
+++ b/CRUNEVO/crunevo/routes/store_routes.py
@@ -1,8 +1,8 @@
 # routes/store_routes.py
 from flask import Blueprint, render_template, request, redirect, url_for, session, flash
 from flask_login import login_required
-from models.product import Product  # ✅ CORREGIDO: usamos 'Product'
-from app import db
+from ..models.product import Product
+from ..models import db
 
 store_bp = Blueprint('store', __name__, url_prefix='/tienda')
 
@@ -30,3 +30,4 @@ def remove_from_cart(producto_id):
     session['carrito'] = carrito
     flash('Producto eliminado del carrito.', 'success')
     return redirect(url_for('store.carrito'))
+

--- a/CRUNEVO/crunevo/templates/base.html
+++ b/CRUNEVO/crunevo/templates/base.html
@@ -18,13 +18,16 @@
                 <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('main.index') }}">Inicio</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('main.feed') }}">Feed</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('note.notes_section') }}">Apuntes</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('store.tienda') }}">Tienda</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('main.ranking') }}">Ranking</a></li>
                 </ul>
                 <ul class="navbar-nav">
                     {% if current_user.is_authenticated %}
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.logout') }}">Salir</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.logout') }}">Salir</a></li>
                     {% else %}
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.login') }}">Ingresar</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.login') }}">Ingresar</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.register') }}">Registrarse</a></li>
                     {% endif %}
                 </ul>
             </div>

--- a/CRUNEVO/crunevo/templates/index.html
+++ b/CRUNEVO/crunevo/templates/index.html
@@ -10,7 +10,7 @@
 {% block content %}
 <section class="hero text-center">
     <h1 class="display-4 fw-bold">Bienvenido a CRUNEVO</h1>
-    <p class="lead">La red social de apuntes para compartir conocimiento universitario.</p>
+    <p class="lead">La red social de apuntes para compartir conocimiento universitario y ganar recompensas.</p>
     <a href="{{ url_for('auth.register') }}" class="btn btn-primary btn-lg mt-3">Únete Gratis</a>
 </section>
 
@@ -19,7 +19,7 @@
         <div class="col-md-4 text-center mb-4">
             <i class="fas fa-file-alt fa-3x mb-3 text-primary"></i>
             <h3>Comparte Apuntes</h3>
-            <p>Sube tus apuntes y ayuda a otros estudiantes.</p>
+            <p>Sube tus apuntes, ayuda a otros estudiantes y acumula créditos que podrás canjear por dinero y productos.</p>
         </div>
         <div class="col-md-4 text-center mb-4">
             <i class="fas fa-users fa-3x mb-3 text-primary"></i>

--- a/CRUNEVO/crunevo/templates/login.html
+++ b/CRUNEVO/crunevo/templates/login.html
@@ -7,7 +7,7 @@
     <div class="text-center mb-4">
         <i class="fas fa-book-reader fa-3x icon-primary"></i>
         <h2 class="mt-2">Iniciar Sesión</h2>
-        <p class="text-muted">Accede a tu cuenta para continuar explorando.</p>
+        <p class="text-muted">Accede a tu cuenta para seguir ganando créditos por compartir tus apuntes.</p>
     </div>
 
     {% if form.errors %}

--- a/CRUNEVO/crunevo/templates/register.html
+++ b/CRUNEVO/crunevo/templates/register.html
@@ -7,7 +7,7 @@
     <div class="text-center mb-4">
         <i class="fas fa-user-plus fa-3x icon-primary"></i>
         <h2 class="mt-2">Crear una Cuenta</h2>
-        <p class="text-muted">Únete a la comunidad y empieza a compartir y descargar apuntes.</p>
+        <p class="text-muted">Únete a la comunidad, comparte apuntes y gana dinero y productos con tus contribuciones.</p>
     </div>
 
     {% if form.errors %}

--- a/CRUNEVO/requirements.txt
+++ b/CRUNEVO/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv==1.1.0
 Flask-Login==0.6.3
 Flask-WTF==1.2.1
 pytest==8.1.1
+boto3==1.34.121


### PR DESCRIPTION
## Summary
- register blueprints for store and notes
- fix imports in store and note routes
- expose links to Apuntes and Tienda in navigation
- highlight rewards for uploading notes on homepage and auth pages
- include boto3 dependency for note uploads

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68424e6fe01c8325a1b3a401e64a2454