### PR TITLE
Update routes to use credits

### DIFF
--- a/CRUNEVO/crunevo/routes/note_routes.py
+++ b/CRUNEVO/crunevo/routes/note_routes.py
@@ -122,7 +122,7 @@ def upload_note():
 
                     user = User.query.get(user_id)
                     if user:
-                        user.points = (user.points or 0) + 10
+                        user.credits = (user.credits or 0) + 10
 
                     db.session.add(new_note)
                     db.session.commit()

--- a/CRUNEVO/crunevo/routes/user_routes.py
+++ b/CRUNEVO/crunevo/routes/user_routes.py
@@ -20,11 +20,11 @@ def profile():
         "likes_received": current_user.likes_received if hasattr(current_user, "likes_received") else 0,
     }
 
-    # Determinar nivel del usuario basado en puntos
+    # Determinar nivel del usuario basado en créditos
     user_level = "Novato"  # Placeholder
-    if current_user.points > 1000:
+    if current_user.credits > 1000:
         user_level = "Experto"
-    elif current_user.points > 100:
+    elif current_user.credits > 100:
         user_level = "Ayudante"
 
     return render_template(


### PR DESCRIPTION
## Summary
- honor new user fields by using `credits` in user routes
- update note upload route to award credits instead of points

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68426d8c85c08325a53fa08b71e9c2cf