### PR TITLE
Improve database config fallback

### DIFF
--- a/CRUNEVO/config.py
+++ b/CRUNEVO/config.py
@@ -13,6 +13,10 @@ class Config:
         default_dir = Path(__file__).resolve().parent / "crunevo" / "instance"
         try:
             default_dir.mkdir(parents=True, exist_ok=True)
+            test_file = default_dir / ".write_test"
+            with open(test_file, "w"):
+                pass
+            test_file.unlink()
         except OSError:
             temp_dir = Path(tempfile.gettempdir()) / "crunevo_instance"
             temp_dir.mkdir(parents=True, exist_ok=True)
@@ -21,7 +25,11 @@ class Config:
     else:
         Path(_custom_dir).mkdir(parents=True, exist_ok=True)
 
-    env_uri = os.getenv("SQLALCHEMY_DATABASE_URI")
+    env_uri = (
+        os.getenv("SQLALCHEMY_DATABASE_URI")
+        or os.getenv("DATABASE_URI")
+        or os.getenv("DATABASE_URL")
+    )
     if env_uri:
         if env_uri.startswith("sqlite:///"):
             db_path = Path(env_uri.replace("sqlite:///", ""))

--- a/CRUNEVO/crunevo/README_DEPLOY.md
+++ b/CRUNEVO/crunevo/README_DEPLOY.md
@@ -16,7 +16,7 @@ Este archivo contiene instrucciones básicas para desplegar la aplicación Flask
     -   `instance/`: Este directorio se creará automáticamente al ejecutar la aplicación y contendrá la base de datos SQLite (`plataforma_apuntes.db`). Asegúrate de que el servidor tenga permisos para escribir en esta ubicación dentro de `src/`.
 -   `requirements.txt`: Lista todas las dependencias de Python necesarias para el proyecto.
 -   `venv/`: Entorno virtual de Python (generalmente no se sube al servidor, se recrea allí).
--   `.env`: Archivo para variables de entorno (ej. `SECRET_KEY`, `DATABASE_URI`, `DATABASE_DIR`). **Importante:** este archivo contiene información sensible y debe configurarse adecuadamente en el servidor. Puedes definir `DATABASE_DIR` para indicar un directorio con permisos de escritura donde se creará la base de datos SQLite. Si no se define, la aplicación intentará crearla dentro del proyecto y, si ese lugar es de solo lectura, utilizará `/tmp` de forma automática.
+-   `.env`: Archivo para variables de entorno (ej. `SECRET_KEY`, `SQLALCHEMY_DATABASE_URI`, `DATABASE_DIR`). **Importante:** este archivo contiene información sensible y debe configurarse adecuadamente en el servidor. Puedes definir `DATABASE_DIR` para indicar un directorio con permisos de escritura donde se creará la base de datos SQLite. Si no se define o el directorio no es escribible, la aplicación intentará usar `/tmp/crunevo_instance` de forma automática.
 
 ## Pasos Generales para el Despliegue:
 
@@ -44,7 +44,7 @@ Este archivo contiene instrucciones básicas para desplegar la aplicación Flask
 5.  **Configurar Variables de Entorno:**
     *   Crea o edita el archivo `.env` en la raíz de `deployment_cantuta_app`.
     *   Asegúrate de que `SECRET_KEY` sea una clave fuerte y única.
-    *   Verifica que `DATABASE_URI` (o `DATABASE_DIR`) apunte a una ubicación con permisos de escritura para la base de datos. Si usas SQLite, puedes establecer `DATABASE_DIR` con el directorio deseado y la aplicación generará allí el archivo `crunevo.sqlite3`.
+    *   Verifica que `SQLALCHEMY_DATABASE_URI` (o `DATABASE_URL`) o `DATABASE_DIR` apunten a una ubicación con permisos de escritura para la base de datos. Si usas SQLite, puedes establecer `DATABASE_DIR` con el directorio deseado y la aplicación generará allí el archivo `crunevo.sqlite3`.
 
 6.  **Inicializar la Base de Datos (si es la primera vez):**
     *   La aplicación está configurada para crear las tablas y el directorio `instance/` automáticamente al iniciarse si no existen. No obstante, verifica que esto ocurra o ejecuta un script de inicialización si es necesario.


### PR DESCRIPTION
## Summary
- verify database directory is writable and fallback to `/tmp/crunevo_instance` if not
- clarify fallback behavior in deployment guide

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684286a4f88883258b2e0ccba46fcbba