### PR TITLE
Fix missing model aliases

### DIFF
--- a/CRUNEVO/crunevo/__init__.py
+++ b/CRUNEVO/crunevo/__init__.py
@@ -3,9 +3,24 @@ from flask import Flask
 from flask_login import LoginManager
 from .models import db
 from .models.user import User as _User
-from .models.note import Note as _Note, Download as _Download, Like as _Like, Report as _Report
+from .models.note import (
+    Note as _Note,
+    Download as _Download,
+    Like as _Like,
+    Report as _Report,
+)
 from .models.product import Product as _Product
 from .models.forum import Pregunta as _Pregunta, Respuesta as _Respuesta
+
+# Expose models without underscores for ease of use across the package
+User = _User
+Note = _Note
+Download = _Download
+Like = _Like
+Report = _Report
+Product = _Product
+Pregunta = _Pregunta
+Respuesta = _Respuesta
 from .routes.main_routes import main_bp
 from .routes.auth_routes import auth_bp
 from .routes.store_routes import store_bp


### PR DESCRIPTION
## Summary
- expose imported models under their conventional names
- update `__init__` to use these aliases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68429ca6910c832593e186000b1f9906