### PR TITLE
Fix writable path logic for SQLite

### DIFF
--- a/CRUNEVO/config.py
+++ b/CRUNEVO/config.py
@@ -21,12 +21,12 @@ class Config:
             fallback.mkdir(parents=True, exist_ok=True)
             return fallback
 
-    _custom_dir = os.getenv("DATABASE_DIR")
-    if not _custom_dir:
+    _custom_dir_env = os.getenv("DATABASE_DIR")
+    if not _custom_dir_env:
         default_dir = _ensure_writable(Path(__file__).resolve().parent / "crunevo" / "instance")
         _custom_dir = str(default_dir)
     else:
-        _custom_dir = str(_ensure_writable(Path(_custom_dir)))
+        _custom_dir = str(_ensure_writable(Path(_custom_dir_env).expanduser()))
 
     env_uri = (
         os.getenv("SQLALCHEMY_DATABASE_URI")
@@ -35,7 +35,7 @@ class Config:
     )
     if env_uri:
         if env_uri.startswith("sqlite:///"):
-            db_path = Path(env_uri.replace("sqlite:///", ""))
+            db_path = Path(env_uri.replace("sqlite:///", "")).expanduser()
             writable_parent = _ensure_writable(db_path.parent)
             db_path = writable_parent / db_path.name
             env_uri = f"sqlite:///{db_path}"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 Crunevo is a small Flask application. The repository contains the `CRUNEVO` folder with the application and tests.
 
-The deployment on platforms such as Render requires that the SQLite database is stored on a writable disk. If the app fails with `sqlite3.OperationalError: unable to open database file` make sure a writable directory is provided through `DATABASE_DIR` or `SQLALCHEMY_DATABASE_URI`.
+The deployment on platforms such as Render requires that the SQLite database is
+stored on a writable disk. If the app fails with
+`sqlite3.OperationalError: unable to open database file` ensure that the
+application can write to the configured path.
+
+Set the environment variable `DATABASE_DIR` (or `SQLALCHEMY_DATABASE_URI`) to a
+writable directory. Paths containing `~` are expanded automatically.
 
 The provided `render.yaml` already mounts a persistent disk at `/data` and sets `DATABASE_DIR=/data` so a simple deployment works out of the box.
 


### PR DESCRIPTION
## Summary
- expand `~` in provided database directory
- document how to set `DATABASE_DIR`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842a1d45760832597c2749368eff989