### PR TITLE
Fix SQLite deployment defaults

### DIFF
--- a/CRUNEVO/config.py
+++ b/CRUNEVO/config.py
@@ -22,11 +22,17 @@ class Config:
             return fallback
 
     _custom_dir_env = os.getenv("DATABASE_DIR")
-    if not _custom_dir_env:
-        default_dir = _ensure_writable(Path(__file__).resolve().parent / "crunevo" / "instance")
-        _custom_dir = str(default_dir)
-    else:
+    if _custom_dir_env:
         _custom_dir = str(_ensure_writable(Path(_custom_dir_env).expanduser()))
+    else:
+        data_dir = Path("/data")
+        if data_dir.is_dir():
+            _custom_dir = str(_ensure_writable(data_dir))
+        else:
+            default_dir = _ensure_writable(
+                Path(__file__).resolve().parent / "crunevo" / "instance"
+            )
+            _custom_dir = str(default_dir)
 
     env_uri = (
         os.getenv("SQLALCHEMY_DATABASE_URI")

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ application can write to the configured path.
 Set the environment variable `DATABASE_DIR` (or `SQLALCHEMY_DATABASE_URI`) to a
 writable directory. Paths containing `~` are expanded automatically.
 
-The provided `render.yaml` already mounts a persistent disk at `/data` and sets `DATABASE_DIR=/data` so a simple deployment works out of the box.
+If `DATABASE_DIR` is not defined, the configuration now checks whether `/data`
+exists and is writable (this is where a Render persistent disk is mounted). If
+it is, that path is used automatically. The provided `render.yaml` mounts a
+persistent disk at `/data` and sets `DATABASE_DIR=/data`, so deployment works
+out of the box.
 
 Run tests with:
 


### PR DESCRIPTION
## Summary
- fallback to `/data` directory when no database path is configured
- document automatic `/data` detection in the README

## Testing
- `pytest -q CRUNEVO/tests`

------
https://chatgpt.com/codex/tasks/task_e_68435230532c832594ca53be63fda501