### PR TITLE
Fix SQLite fallback

### DIFF
--- a/CRUNEVO/config.py
+++ b/CRUNEVO/config.py
@@ -22,11 +22,17 @@ class Config:
             return fallback
 
     _custom_dir_env = os.getenv("DATABASE_DIR")
-    if not _custom_dir_env:
-        default_dir = _ensure_writable(Path(__file__).resolve().parent / "crunevo" / "instance")
-        _custom_dir = str(default_dir)
-    else:
+    if _custom_dir_env:
         _custom_dir = str(_ensure_writable(Path(_custom_dir_env).expanduser()))
+    else:
+        data_dir = Path("/data")
+        if data_dir.exists() and os.access(data_dir, os.W_OK):
+            _custom_dir = str(_ensure_writable(data_dir))
+        else:
+            default_dir = _ensure_writable(
+                Path(__file__).resolve().parent / "crunevo" / "instance"
+            )
+            _custom_dir = str(default_dir)
 
     env_uri = (
         os.getenv("SQLALCHEMY_DATABASE_URI")

--- a/README.md
+++ b/README.md
@@ -10,7 +10,13 @@ application can write to the configured path.
 Set the environment variable `DATABASE_DIR` (or `SQLALCHEMY_DATABASE_URI`) to a
 writable directory. Paths containing `~` are expanded automatically.
 
-The provided `render.yaml` already mounts a persistent disk at `/data` and sets `DATABASE_DIR=/data` so a simple deployment works out of the box.
+If `DATABASE_DIR` is not defined, the configuration first checks whether the
+directory `/data` exists and is writable. This is where a Render persistent disk
+is mounted. If the check succeeds, that path is used automatically. Otherwise a
+writable directory is created inside the application folder (or in the system
+temporary directory) so the application can still run, though the data will not
+be persisted. The provided `render.yaml` mounts a persistent disk at `/data` and
+sets `DATABASE_DIR=/data`, so deployment works out of the box.
 
 Run tests with:
 


### PR DESCRIPTION
## Summary
- improve detection for `/data` directory before using it for SQLite
- clarify README about temporary directory fallback

## Testing
- `pytest -q tests`


------
https://chatgpt.com/codex/tasks/task_e_68435230532c832594ca53be63fda501