### PR TITLE
Fix Render deployment

### DIFF
--- a/CRUNEVO/requirements.txt
+++ b/CRUNEVO/requirements.txt
@@ -7,3 +7,4 @@ Flask-Login==0.6.3
 Flask-WTF==1.2.1
 pytest==8.1.1
 boto3==1.34.121
+gunicorn==21.2.0

--- a/README.md
+++ b/README.md
@@ -47,3 +47,12 @@ out of the box.
    ```bash
    pytest -q CRUNEVO/tests
    ```
+
+## Deployment on Render
+
+The repository includes a `render.yaml` file that builds the project and starts the application with Gunicorn. A persistent disk is mounted at `/data` and the environment variable `DATABASE_DIR` is set to that path so the SQLite database can be created. Gunicorn is listed in `CRUNEVO/requirements.txt` so it is installed automatically during the build step.
+
+1. Push the repository to a new Render web service.
+2. Make sure the service has a persistent disk attached at `/data`.
+3. Deploy; Render will install the requirements and start the app using the command defined in `render.yaml`.
+


### PR DESCRIPTION
## Summary
- include `gunicorn` in dependencies
- document Render deployment setup

## Testing
- `pip install -r CRUNEVO/requirements.txt`
- `pytest -q CRUNEVO/tests`

------
https://chatgpt.com/codex/tasks/task_e_68435e38f9b883259ba2ede34639f5a1