### PR TITLE
Fix unused import in note_routes

### DIFF
--- a/CRUNEVO/crunevo/routes/note_routes.py
+++ b/CRUNEVO/crunevo/routes/note_routes.py
@@ -2,7 +2,7 @@ from flask import Blueprint, render_template, request, redirect, url_for, flash,
 from datetime import datetime
 import os
 
-from ..utils.storage import ALLOWED_EXTENSIONS, allowed_file, upload_file_to_s3
+from ..utils.storage import allowed_file, upload_file_to_s3
 
 from ..models import db
 from ..models.note import Note


### PR DESCRIPTION
## Summary
- remove unused ALLOWED_EXTENSIONS import from `note_routes.py`
- run pyflakes to ensure clean static checks

## Testing
- `pyflakes CRUNEVO/crunevo/routes/note_routes.py`

------
https://chatgpt.com/codex/tasks/task_e_684382a339a483259e5e54f9ee8cbab6