### PR TITLE
Remove tmp db line and clarify test deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ __pycache__/
 *.pyd
 
 # local test artifacts
-/tmp_test_db
 
 # environment files
 .env

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ out of the box.
    ```bash
    pytest -q CRUNEVO/tests
    ```
+   Make sure the requirements are installed first:
+
+   ```bash
+   pip install -r CRUNEVO/requirements.txt
+   ```
 
 ## Deployment on Render
 


### PR DESCRIPTION
## Summary
- remove obsolete `/tmp_test_db` entry from `.gitignore`
- note requirement to install dependencies before running tests

## Testing
- `pip install -r CRUNEVO/requirements.txt`
- `pytest -q CRUNEVO/tests`

------
https://chatgpt.com/codex/tasks/task_e_68438acd52d08325984c838afc3b5760