### PR TITLE
Add Dockerfile and doc updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use an official Python runtime as the base image
+FROM python:3.12-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy project files into the container
+COPY . /app
+
+# Install dependencies
+RUN pip install --upgrade pip && pip install -r requirements.txt
+
+# Expose the port the app runs on
+EXPOSE 8080
+
+# Command to run the application
+CMD ["gunicorn", "-b", "0.0.0.0:8080", "crunevo.run:app"]

--- a/README.md
+++ b/README.md
@@ -87,3 +87,14 @@ gunicorn -b 0.0.0.0:$PORT crunevo.run:app
 Without a volume the application falls back to a temporary directory and the
 data will be lost on redeploys.
 
+
+## Docker
+
+You can build and run the application using Docker:
+
+```bash
+docker build -t crunevo .
+docker run -p 8080:8080 crunevo
+```
+
+The container exposes port `8080` by default and starts the app with Gunicorn.


### PR DESCRIPTION
## Summary
- add Dockerfile for container builds
- document Docker workflow in README

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q crunevo/tests`
- `docker build -t crunevo .` *(fails: command not found)*
- `docker run -p 8080:8080 crunevo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843a541f3f08325888c46985743781b