### PR TITLE
Ensure Railway-compatible port in run.py

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,8 +1,8 @@
-from crunevo.app import create_app
+import os
+from crunevo import create_app
 
 app = create_app()
 
-if __name__ == '__main__':
-    import os
-    port = int(os.environ.get('PORT', 5000))
-    app.run(host='0.0.0.0', port=port)
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 8080))
+    app.run(host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- update `run.py` to read PORT environment variable at startup
- default to port 8080 and listen on `0.0.0.0`

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843c727da988325bd091317532ebfbf