### PR TITLE
Fix Railway deployment config

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,4 +14,4 @@ RUN pip install --upgrade pip && pip install -r requirements.txt
 EXPOSE 8080
 
 # Command to run the application
-CMD ["gunicorn", "-b", "0.0.0.0:8080", "crunevo.run:app"]
+CMD ["gunicorn", "-b", "0.0.0.0:$PORT", "run:app"]

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ database there.
 Run the service with Gunicorn just as in Render:
 
 ```bash
-gunicorn -b 0.0.0.0:$PORT crunevo.run:app
+gunicorn -b 0.0.0.0:$PORT run:app
 ```
 
 Without a volume the application falls back to a temporary directory and the

--- a/crunevo/README_DEPLOY_RAILWAY.md
+++ b/crunevo/README_DEPLOY_RAILWAY.md
@@ -17,7 +17,7 @@
 
 ### Comando de inicio
 ```bash
-gunicorn -b 0.0.0.0:$PORT crunevo.run:app
+gunicorn -b 0.0.0.0:$PORT run:app
 ```
 
 ## 3. Notas


### PR DESCRIPTION
## Summary
- rename Dockerfile so Railway uses Nixpacks
- document correct start command using `$PORT`

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843ccf1684c832587730356174f1386