### PR TITLE
Fix email validation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ Flask-WTF==1.2.1
 pytest==8.1.1
 boto3==1.34.121
 gunicorn==21.2.0
+email-validator==2.2.0


### PR DESCRIPTION
## Summary
- add `email-validator` to requirements for form validation

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843d4f5a7908325826d2f73d3c02651