### PR TITLE
Fix profile link and navbar tabs

### DIFF
--- a/crunevo/__init__.py
+++ b/crunevo/__init__.py
@@ -1,5 +1,5 @@
 
-from flask import Flask
+from flask import Flask, render_template
 from flask_login import LoginManager
 from crunevo.models import db
 from crunevo.models.user import User as _User
@@ -62,5 +62,9 @@ def create_app():
     app.register_blueprint(forum_bp)
     app.register_blueprint(user_bp)
     app.register_blueprint(admin_bp)
+
+    @app.errorhandler(500)
+    def internal_error(error):
+        return render_template("500.html"), 500
 
     return app

--- a/crunevo/routes/note_routes.py
+++ b/crunevo/routes/note_routes.py
@@ -58,6 +58,7 @@ def notes_section():
 
 # --- Ruta: Subir Apunte ---
 @note_bp.route("/subir", methods=["GET", "POST"])
+@note_bp.route("/upload", methods=["GET", "POST"])
 def upload_note():
     if request.method == "POST":
         user_id = 1  # Usuario simulado por ahora

--- a/crunevo/routes/user_routes.py
+++ b/crunevo/routes/user_routes.py
@@ -63,3 +63,11 @@ def edit_profile():
 
     # Prellenar el formulario para la solicitud GET
     return render_template("edit_profile.html", user=user)
+
+
+@user_bp.route("/notes")
+@login_required
+def my_notes():
+    """Display notes uploaded by the current user."""
+    uploaded_notes = current_user.notes
+    return render_template("my_notes.html", notes=uploaded_notes)

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -23,14 +23,14 @@
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('store.tienda') }}">Tienda</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('main.ranking') }}">Ranking</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('forum.foro') }}">Foro</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('main.about') }}">Acerca de</a></li>
                     {% if current_user.is_authenticated %}
-                        <li class="nav-item"><a class="nav-link" href="{{ url_for('user.profile') }}">Mis Apuntes</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{{ url_for('user.my_notes') }}">Mis Apuntes</a></li>
                         <li class="nav-item"><a class="nav-link" href="{{ url_for('note.upload_note') }}">Subir</a></li>
                         {% if current_user.role == 'admin' %}
                             <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.dashboard') }}">Panel Admin</a></li>
                         {% endif %}
                     {% endif %}
+                    <li class="nav-item"><a class="nav-link" href="{{ url_for('main.about') }}">Acerca de</a></li>
                 </ul>
                 <ul class="navbar-nav mb-2 mb-lg-0">
                     {% if current_user.is_authenticated %}

--- a/crunevo/templates/my_notes.html
+++ b/crunevo/templates/my_notes.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Mis Apuntes</h2>
+<ul>
+  {% for note in notes %}
+  <li>{{ note.title }}</li>
+  {% else %}
+  <li>No hay apuntes.</li>
+  {% endfor %}
+</ul>
+<a href="{{ url_for('main.index') }}">Volver al inicio</a>
+{% endblock %}

--- a/crunevo/templates/perfil.html
+++ b/crunevo/templates/perfil.html
@@ -5,5 +5,5 @@
 <p><strong>Email:</strong> {{ current_user.email }}</p>
 <p><strong>Rol:</strong> {{ current_user.role }}</p>
 <p><strong>Créditos:</strong> {{ current_user.creditos }}</p>
-<a href="{{ url_for('main_bp.index') }}">Volver al inicio</a>
+<a href="{{ url_for('main.index') }}">Volver al inicio</a>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add 500 error handler
- fix profile link to homepage
- expose '/upload' and '/user/notes' routes
- update navbar with new routes
- add minimal user notes template

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843d78fcad88325bec8f5d00de96643