### PR TITLE
Implement user feed with protected route

### DIFF
--- a/crunevo/routes/main_routes.py
+++ b/crunevo/routes/main_routes.py
@@ -1,12 +1,14 @@
 
-from flask import Blueprint, render_template
-from flask_login import login_required
+from flask import Blueprint, render_template, redirect, url_for
+from flask_login import login_required, current_user
 from crunevo.models.note import Note
 
 main_bp = Blueprint('main', __name__)
 
 @main_bp.route('/')
 def index():
+    if current_user.is_authenticated:
+        return redirect(url_for('main.feed'))
     return render_template('index.html')
 
 
@@ -19,7 +21,7 @@ def ranking():
 @login_required
 def feed():
     notes = Note.query.order_by(Note.upload_date.desc()).limit(20).all()
-    return render_template('feed.html', notes=notes)
+    return render_template('feed.html', notes=notes, user=current_user)
 
 
 @main_bp.route('/about')

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -18,7 +18,9 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('main.index') }}">Inicio</a></li>
-                    <li class="nav-item"><a class="nav-link" href="{{ url_for('main.feed') }}">Feed</a></li>
+                    {% if current_user.is_authenticated %}
+                        <li class="nav-item"><a class="nav-link" href="{{ url_for('main.feed') }}">Feed</a></li>
+                    {% endif %}
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('note.notes_section') }}">Apuntes</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('store.tienda') }}">Tienda</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('main.ranking') }}">Ranking</a></li>

--- a/crunevo/templates/feed.html
+++ b/crunevo/templates/feed.html
@@ -2,18 +2,52 @@
 
 {% block title %}Feed{% endblock %}
 
+{% block head_extra %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/custom_feed.css') }}">
+{% endblock %}
+
 {% block content %}
-<h2 class="mb-4">Últimos Apuntes</h2>
-<div class="feed">
-  {% for note in notes %}
-  <div class="card mb-3">
-    <div class="card-body">
-      <h5 class="card-title">{{ note.title }}</h5>
-      <p class="card-text">{{ note.description or '' }}</p>
+<div class="mb-4">
+    <div class="card p-3 shadow-sm">
+        <div class="d-flex align-items-center">
+            <img src="{{ user.profile_picture_url or url_for('static', filename='images/default_avatar.png') }}" alt="Avatar" class="rounded-circle me-3" width="50" height="50">
+            <input type="text" class="form-control me-2" placeholder="¿Qué estás estudiando?" readonly>
+            <a href="{{ url_for('note.upload_note') }}" class="btn btn-success"><i class="fas fa-upload me-1"></i>Subir Apunte</a>
+        </div>
     </div>
-  </div>
-  {% else %}
-  <p>No hay apuntes disponibles.</p>
-  {% endfor %}
+</div>
+
+<h2 class="mb-3">Últimos Apuntes</h2>
+<div class="feed">
+    {% for note in notes %}
+    <div class="card mb-3">
+        <div class="row g-0">
+            <div class="col-md-2 d-flex align-items-center justify-content-center">
+                {% if note.file_type == 'pdf' %}
+                <i class="far fa-file-pdf fa-3x text-danger"></i>
+                {% else %}
+                <i class="far fa-file-alt fa-3x text-muted"></i>
+                {% endif %}
+            </div>
+            <div class="col-md-10">
+                <div class="card-body">
+                    <h5 class="card-title mb-1">{{ note.title }}</h5>
+                    <p class="card-text mb-1"><small class="text-muted">{{ note.course or '' }} - {{ note.faculty or '' }}</small></p>
+                    <p class="card-text">{{ note.description|truncate(120) }}</p>
+                    <div class="d-flex justify-content-between align-items-center">
+                        <div>
+                            <span class="me-3"><i class="fas fa-heart text-danger me-1"></i>{{ note.likes_count or 0 }}</span>
+                            <span class="me-3"><i class="fas fa-comment me-1"></i>0</span>
+                            <span><i class="fas fa-share"></i></span>
+                        </div>
+                        <a href="{{ url_for('note.download_note_file', note_id=note.id) }}" class="btn btn-sm btn-outline-primary">Descargar</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% else %}
+    <p>No hay apuntes disponibles.</p>
+    {% endfor %}
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- redirect authenticated users from `/` to `/feed`
- show feed page only when logged in
- add new feed design with upload prompt and note cards
- hide feed nav link when logged out

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843dad1feb48325b1c4b77b69fa9b4d