### PR TITLE
Redirect feed to home

### DIFF
--- a/crunevo/routes/auth_routes.py
+++ b/crunevo/routes/auth_routes.py
@@ -10,13 +10,13 @@ auth_bp = Blueprint('auth', __name__)
 @auth_bp.route('/login', methods=['GET', 'POST'])
 def login():
     if current_user.is_authenticated:
-        return redirect(url_for('main.feed'))
+        return redirect(url_for('main.index'))
     form = LoginForm()
     if form.validate_on_submit():
         user = User.query.filter_by(email=form.email.data).first()
         if user and user.check_password(form.password.data):
             login_user(user, remember=form.remember_me.data)
-            return redirect(url_for('main.feed'))
+            return redirect(url_for('main.index'))
         flash('Credenciales inválidas.', 'danger')
     return render_template('login.html', form=form)
 
@@ -24,7 +24,7 @@ def login():
 @auth_bp.route('/register', methods=['GET', 'POST'])
 def register():
     if current_user.is_authenticated:
-        return redirect(url_for('main.feed'))
+        return redirect(url_for('main.index'))
     form = RegisterForm()
     if form.validate_on_submit():
         if User.query.filter_by(email=form.email.data).first():
@@ -39,7 +39,7 @@ def register():
             db.session.add(user)
             db.session.commit()
             login_user(user)
-            return redirect(url_for('main.feed'))
+            return redirect(url_for('main.index'))
     return render_template('register.html', form=form)
 
 

--- a/crunevo/routes/main_routes.py
+++ b/crunevo/routes/main_routes.py
@@ -8,7 +8,8 @@ main_bp = Blueprint('main', __name__)
 @main_bp.route('/')
 def index():
     if current_user.is_authenticated:
-        return redirect(url_for('main.feed'))
+        notes = Note.query.order_by(Note.upload_date.desc()).limit(20).all()
+        return render_template('feed.html', notes=notes, user=current_user)
     return render_template('index.html')
 
 
@@ -18,10 +19,8 @@ def ranking():
 
 
 @main_bp.route('/feed')
-@login_required
-def feed():
-    notes = Note.query.order_by(Note.upload_date.desc()).limit(20).all()
-    return render_template('feed.html', notes=notes, user=current_user)
+def feed_redirect():
+    return redirect(url_for('main.index'))
 
 
 @main_bp.route('/about')

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -18,9 +18,6 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('main.index') }}">Inicio</a></li>
-                    {% if current_user.is_authenticated %}
-                        <li class="nav-item"><a class="nav-link" href="{{ url_for('main.feed') }}">Feed</a></li>
-                    {% endif %}
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('note.notes_section') }}">Apuntes</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('store.tienda') }}">Tienda</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('main.ranking') }}">Ranking</a></li>

--- a/crunevo/templates/index.html
+++ b/crunevo/templates/index.html
@@ -30,7 +30,7 @@
             </div>
             <div class="col-md-4 text-center mb-4">
                 <div class="feature-card p-3 h-100">
-                    <a href="{{ url_for('main.feed') }}" class="text-decoration-none text-dark">
+                    <a href="{{ url_for('main.index') }}" class="text-decoration-none text-dark">
                         <i class="fas fa-users fa-3x mb-3 icon-primary"></i>
                         <h3>Conéctate</h3>
                         <p>Sigue a tus compañeros y descubre nuevo material.</p>


### PR DESCRIPTION
## Summary
- render feed when hitting the site root for logged-in users
- redirect legacy `/feed` to `/`
- send login and registration redirects to the home page
- simplify navbar by linking to `/` unconditionally
- update landing page link to `/`

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843de2e4d50832582ed62be4803c1fe