### PR TITLE
Fix note upload flow

### DIFF
--- a/crunevo/config.py
+++ b/crunevo/config.py
@@ -78,3 +78,5 @@ class Config:
         str(Path(__file__).resolve().parent / "static" / "uploads" / "notes"),
     )
     Path(NOTE_UPLOAD_FOLDER).mkdir(parents=True, exist_ok=True)
+
+    MAX_NOTE_FILE_SIZE_MB = int(os.getenv("MAX_NOTE_FILE_SIZE_MB", "20"))

--- a/crunevo/config.py
+++ b/crunevo/config.py
@@ -72,3 +72,9 @@ class Config:
     # application runs on platforms with read-only source directories as it
     # helps diagnose database initialization errors.
     print(f"Using database URI: {SQLALCHEMY_DATABASE_URI}")
+
+    NOTE_UPLOAD_FOLDER = os.getenv(
+        "NOTE_UPLOAD_FOLDER",
+        str(Path(__file__).resolve().parent / "static" / "uploads" / "notes"),
+    )
+    Path(NOTE_UPLOAD_FOLDER).mkdir(parents=True, exist_ok=True)

--- a/crunevo/templates/feed.html
+++ b/crunevo/templates/feed.html
@@ -39,7 +39,7 @@
                     </p>
                     <p class="mb-2">{{ note.description[:120] }}...</p>
                     <div class="d-flex justify-content-between">
-                        <a href="{{ url_for('note.download_note_file', note_id=note.id) }}" class="btn btn-sm btn-outline-dark">📄 Ver Apunte</a>
+                        <a href="{{ url_for('note.note_detail', note_id=note.id) }}" class="btn btn-sm btn-outline-dark">📄 Ver Apunte</a>
                         <small class="text-muted align-self-center">{{ note.page_count or '?' }} páginas</small>
                     </div>
                 </div>
@@ -49,6 +49,7 @@
             <button class="btn btn-sm btn-outline-secondary">❤️ Me gusta</button>
             <button class="btn btn-sm btn-outline-secondary">💬 Comentar</button>
             <button class="btn btn-sm btn-outline-secondary">🔖 Guardar</button>
+            <a href="{{ url_for('note.download_note_file', note_id=note.id) }}" class="btn btn-sm btn-outline-primary">⬇️ Descargar</a>
             <button class="btn btn-sm btn-outline-secondary ms-auto">📤 Compartir</button>
         </div>
     </div>

--- a/crunevo/templates/note_detail.html
+++ b/crunevo/templates/note_detail.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+
+{% block title %}{{ note.title }}{% endblock %}
+
+{% block content %}
+<div class="container my-4">
+  <h2 class="mb-2">{{ note.title }}</h2>
+  <p class="text-muted">Subido el {{ note.upload_date.strftime('%d/%m/%Y') }}</p>
+  <div class="mb-4">
+    {% if note.file_type == 'pdf' %}
+      <iframe src="{{ note.file_url }}" width="100%" height="600" class="border"></iframe>
+    {% elif note.file_url and note.file_type in ['jpg', 'jpeg', 'png'] %}
+      <img src="{{ note.file_url }}" class="img-fluid" alt="{{ note.title }}">
+    {% else %}
+      <a href="{{ note.file_url }}" target="_blank">Descargar archivo</a>
+    {% endif %}
+  </div>
+  <p>{{ note.description }}</p>
+  <a href="{{ url_for('note.download_note_file', note_id=note.id) }}" class="btn btn-primary me-2">Descargar</a>
+  <a href="{{ note.file_url }}" class="btn btn-secondary" target="_blank">Compartir</a>
+</div>
+{% endblock %}

--- a/crunevo/templates/upload_note.html
+++ b/crunevo/templates/upload_note.html
@@ -185,7 +185,7 @@ document.addEventListener('DOMContentLoaded', () => {
         fileInput.addEventListener('change', function() {
             if (this.files && this.files[0]) {
                 const file = this.files[0];
-                filePreview.textContent = `Archivo seleccionado: ${file.name} (${(file.size / 1024 / 1024).toFixed(2)} MB)`;
+                filePreview.textContent = `Archivo: ${file.name} - ${(file.size / 1024 / 1024).toFixed(2)} MB - ${file.type || 'tipo desconocido'}`;
                 // Aquí se podría añadir lógica para mostrar miniatura si es imagen
             } else {
                 filePreview.textContent = '';

--- a/crunevo/utils/storage.py
+++ b/crunevo/utils/storage.py
@@ -7,7 +7,7 @@ from botocore.exceptions import NoCredentialsError, ClientError
 import boto3
 
 # Allowed extensions for note uploads
-ALLOWED_EXTENSIONS = {"pdf", "png", "jpg", "jpeg", "doc", "docx"}
+ALLOWED_EXTENSIONS = {"pdf", "png", "jpg", "jpeg", "doc", "docx", "txt"}
 
 
 def allowed_file(filename: str) -> bool:


### PR DESCRIPTION
## Summary
- allow local uploads if S3 is not configured
- configure upload directory in app config
- expose helper to save files locally
- serve local downloads from `/notes/<id>/download`
- add placeholder uploads directory

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843f3780ab48325938e59b5d2cdf772