### PR TITLE
Improve mobile menu interaction

### DIFF
--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -47,3 +47,12 @@ body {
     opacity: 0.9;
     box-shadow: 0 0 5px rgba(0,0,0,0.1);
 }
+
+/* Estilos para el menú offcanvas en móviles */
+.offcanvas .nav-link {
+    font-size: 1.2rem;
+    padding: 0.75rem 1rem;
+}
+.offcanvas .nav-link i {
+    width: 1.5rem;
+}

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -1,12 +1,24 @@
-// Lógica para el menú hamburguesa
-const navbarToggler = document.querySelector(".navbar-toggler");
-const navbarCollapse = document.querySelector(".navbar-collapse");
+// Lógica para el menú offcanvas y su integración con el botón atrás
+document.addEventListener("DOMContentLoaded", () => {
+    const offcanvasEl = document.getElementById("mobileMenu");
+    if (offcanvasEl) {
+        const offcanvas = new bootstrap.Offcanvas(offcanvasEl);
+        offcanvasEl.addEventListener("shown.bs.offcanvas", () => {
+            history.pushState({ offcanvas: true }, "");
+        });
+        offcanvasEl.addEventListener("hidden.bs.offcanvas", () => {
+            if (history.state && history.state.offcanvas) {
+                history.back();
+            }
+        });
 
-if (navbarToggler && navbarCollapse) {
-    navbarToggler.addEventListener("click", () => {
-        navbarCollapse.classList.toggle("show");
-    });
-}
+        window.addEventListener("popstate", (evt) => {
+            if (evt.state && evt.state.offcanvas) {
+                offcanvas.hide();
+            }
+        });
+    }
+});
 
 // Lógica para el Modal de Búsqueda Global
 document.addEventListener("DOMContentLoaded", () => {

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -12,10 +12,11 @@
     <nav class="navbar navbar-expand-lg navbar-light bg-light mb-4 shadow-sm">
         <div class="container-fluid">
             <a class="navbar-brand" href="{{ url_for('main.index') }}">CRUNEVO</a>
-            <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+            <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#mobileMenu" aria-controls="mobileMenu" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
-            <div class="collapse navbar-collapse" id="navbarNav">
+
+            <div class="d-none d-lg-flex flex-grow-1 justify-content-between" id="navbarNav">
                 <ul class="navbar-nav me-auto mb-2 mb-lg-0">
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('main.index') }}">Inicio</a></li>
                     <li class="nav-item"><a class="nav-link" href="{{ url_for('note.notes_section') }}">Apuntes</a></li>
@@ -40,6 +41,38 @@
                         <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.register') }}">Registrarse</a></li>
                     {% endif %}
                 </ul>
+            </div>
+
+            <div class="offcanvas offcanvas-start" tabindex="-1" id="mobileMenu" aria-labelledby="mobileMenuLabel">
+                <div class="offcanvas-header">
+                    <h5 class="offcanvas-title" id="mobileMenuLabel">CRUNEVO</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>
+                </div>
+                <div class="offcanvas-body">
+                    <ul class="navbar-nav">
+                        <li class="nav-item"><a class="nav-link" href="{{ url_for('main.index') }}"><i class="fas fa-home me-2"></i>Inicio</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{{ url_for('note.notes_section') }}"><i class="fas fa-book me-2"></i>Apuntes</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{{ url_for('store.tienda') }}"><i class="fas fa-store me-2"></i>Tienda</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{{ url_for('main.ranking') }}"><i class="fas fa-trophy me-2"></i>Ranking</a></li>
+                        <li class="nav-item"><a class="nav-link" href="{{ url_for('forum.foro') }}"><i class="fas fa-comments me-2"></i>Foro</a></li>
+                        {% if current_user.is_authenticated %}
+                            <li class="nav-item"><a class="nav-link" href="{{ url_for('user.my_notes') }}"><i class="fas fa-folder-open me-2"></i>Mis Apuntes</a></li>
+                            <li class="nav-item"><a class="nav-link" href="{{ url_for('note.upload_note') }}"><i class="fas fa-upload me-2"></i>Subir</a></li>
+                            {% if current_user.role == 'admin' %}
+                                <li class="nav-item"><a class="nav-link" href="{{ url_for('admin.dashboard') }}"><i class="fas fa-tools me-2"></i>Panel Admin</a></li>
+                            {% endif %}
+                        {% endif %}
+                        <li class="nav-item"><a class="nav-link" href="{{ url_for('main.about') }}"><i class="fas fa-info-circle me-2"></i>Acerca de</a></li>
+                        <hr>
+                        {% if current_user.is_authenticated %}
+                            <li class="nav-item"><a class="nav-link" href="{{ url_for('user.profile') }}"><i class="fas fa-user-circle me-2"></i>Perfil</a></li>
+                            <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.logout') }}"><i class="fas fa-sign-out-alt me-2"></i>Salir</a></li>
+                        {% else %}
+                            <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.login') }}"><i class="fas fa-sign-in-alt me-2"></i>Ingresar</a></li>
+                            <li class="nav-item"><a class="nav-link" href="{{ url_for('auth.register') }}"><i class="fas fa-user-plus me-2"></i>Registrarse</a></li>
+                        {% endif %}
+                    </ul>
+                </div>
             </div>
         </div>
     </nav>


### PR DESCRIPTION
## Summary
- modernize mobile navigation with a Bootstrap offcanvas drawer
- style the offcanvas menu for larger tap targets
- integrate history state to let the browser back button close the menu

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q crunevo/tests`

------
https://chatgpt.com/codex/tasks/task_e_684464210848832589ffc7db8a2633e7