### PR TITLE
[Refactor] Rediseñar feed de apuntes para móviles con estilo moderno

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,3 +76,15 @@ pytest -q
   - `crunevo/templates/base.html`
   - `crunevo/static/js/main.js`
   - `crunevo/static/css/style.css`
+
+### [Refactor] Rediseñar feed de apuntes para móviles con estilo moderno (2025-06-08)
+- Modificados:
+  - `crunevo/templates/feed.html`
+  - `crunevo/static/css/custom_feed.css`
+- Detalles:
+  - Se reorganizó el HTML usando `article.note-card` y un contenedor `.feed-container` para un aspecto de app.
+  - Se añadió diseño responsive con `border-radius`, `box-shadow` e íconos centrados.
+  - Las miniaturas ahora ocupan todo el ancho superior y el botón principal se centra.
+- Pruebas:
+  ✅ `pip install -r requirements.txt`
+  ✅ `PYTHONPATH=. pytest -q crunevo/tests`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,3 +88,15 @@ pytest -q
 - Pruebas:
   ✅ `pip install -r requirements.txt`
   ✅ `PYTHONPATH=. pytest -q crunevo/tests`
+
+### [Enhancement] Mejoras visuales en el feed móvil (2025-06-08)
+- Modificados:
+  - `crunevo/templates/feed.html`
+  - `crunevo/static/css/custom_feed.css`
+- Detalles:
+  - Se añadió animación de aparición a las tarjetas con `.animate-fade` y `@keyframes fadeUp`.
+  - Se agregó subtítulo informativo, nuevo placeholder y mejoras de accesibilidad con `aria-label`.
+  - Botón de subir con mayor padding en móviles.
+- Pruebas:
+  ✅ `pip install -r requirements.txt`
+  ✅ `PYTHONPATH=. pytest -q crunevo/tests`

--- a/crunevo/static/css/custom_feed.css
+++ b/crunevo/static/css/custom_feed.css
@@ -1,15 +1,60 @@
-
-body {
-    background-color: #f9f9f9;
+:root {
+    --card-radius: 1rem;
+    --card-shadow: 0 2px 5px rgba(0,0,0,0.05);
 }
 
-.feed-divider {
-    border-top: 1px solid #e0e0e0;
+.feed-container {
+    width: 100%;
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 }
-.feed .card {
-    transition: transform 0.2s ease;
+
+.note-card {
+    border-radius: var(--card-radius);
+    box-shadow: var(--card-shadow);
+    overflow: hidden;
 }
-.feed .card:hover {
-    transform: scale(1.01);
-    box-shadow: 0 0 10px rgba(0,0,0,0.08);
+
+.note-image img,
+.note-image embed {
+    width: 100%;
+    height: auto;
+    border-radius: var(--card-radius) var(--card-radius) 0 0;
+}
+
+.note-title {
+    font-weight: 600;
+    font-size: 1.25rem;
+}
+
+.note-meta {
+    font-size: 0.875rem;
+    color: #6c757d;
+}
+
+.note-actions {
+    display: flex;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    border-top: none;
+    padding: 0.75rem;
+}
+
+@media (max-width: 768px) {
+    .feed-container {
+        padding: 1rem;
+    }
+    .note-card {
+        width: 100%;
+        margin-bottom: 1rem;
+    }
+    .create-note input.form-control {
+        font-size: 0.9rem;
+        padding: 0.25rem 0.5rem;
+    }
 }

--- a/crunevo/static/css/custom_feed.css
+++ b/crunevo/static/css/custom_feed.css
@@ -19,6 +19,21 @@
     overflow: hidden;
 }
 
+.animate-fade {
+    animation: fadeUp 0.5s ease both;
+}
+
+@keyframes fadeUp {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
 .note-image img,
 .note-image embed {
     width: 100%;
@@ -56,5 +71,9 @@
     .create-note input.form-control {
         font-size: 0.9rem;
         padding: 0.25rem 0.5rem;
+    }
+    .create-note .btn {
+        padding-left: 1rem;
+        padding-right: 1rem;
     }
 }

--- a/crunevo/templates/feed.html
+++ b/crunevo/templates/feed.html
@@ -11,18 +11,19 @@
     <div class="create-note card p-3 shadow-sm">
         <div class="d-flex align-items-center">
             <img src="{{ user.profile_picture_url or url_for('static', filename='images/default_avatar.png') }}" alt="Avatar" class="rounded-circle me-3" width="40" height="40">
-            <input type="text" class="form-control me-2" placeholder="¿Qué estás estudiando?" readonly>
+            <input type="text" class="form-control me-2" placeholder="Comparte lo que estás aprendiendo..." readonly>
             {% if current_user.is_authenticated %}
             <a href="{{ url_for('note.upload_note') }}" class="btn btn-primary ms-auto"><i class="fas fa-upload me-1"></i>Subir</a>
             {% endif %}
         </div>
     </div>
 
+    <p class="text-muted small">Explora apuntes recientes compartidos por la comunidad</p>
     <h2 class="fw-bold mb-3">📄 Últimos Apuntes</h2>
 
     <div class="feed">
     {% for note in notes %}
-    <article class="note-card card">
+    <article class="note-card card animate-fade">
         <div class="note-image">
             {% if note.file_type == 'pdf' %}
                 <embed src="{{ note.file_url }}#page=1" type="application/pdf" class="w-100" style="height:180px; object-fit:cover;" />
@@ -47,11 +48,11 @@
             <p class="text-center text-muted mb-0">{{ note.page_count or '?' }} páginas</p>
         </div>
         <div class="note-actions card-footer bg-white">
-            <button class="btn btn-sm btn-outline-secondary">❤️ Me gusta</button>
-            <button class="btn btn-sm btn-outline-secondary">💬 Comentar</button>
-            <button class="btn btn-sm btn-outline-secondary">🔖 Guardar</button>
-            <a href="{{ url_for('note.download_note_file', note_id=note.id) }}" class="btn btn-sm btn-outline-primary">⬇️ Descargar</a>
-            <button class="btn btn-sm btn-outline-secondary">📤 Compartir</button>
+            <button class="btn btn-sm btn-outline-secondary" aria-label="Me gusta">❤️ Me gusta</button>
+            <button class="btn btn-sm btn-outline-secondary" aria-label="Comentar">💬 Comentar</button>
+            <button class="btn btn-sm btn-outline-secondary" aria-label="Guardar">🔖 Guardar</button>
+            <a href="{{ url_for('note.download_note_file', note_id=note.id) }}" class="btn btn-sm btn-outline-primary" aria-label="Descargar">⬇️ Descargar</a>
+            <button class="btn btn-sm btn-outline-secondary" aria-label="Compartir">📤 Compartir</button>
         </div>
     </article>
 

--- a/crunevo/templates/feed.html
+++ b/crunevo/templates/feed.html
@@ -7,58 +7,53 @@
 {% endblock %}
 
 {% block content %}
-<div class="mb-4">
-    <div class="card p-3 shadow-sm">
+<div class="feed-container">
+    <div class="create-note card p-3 shadow-sm">
         <div class="d-flex align-items-center">
-            <img src="{{ user.profile_picture_url or url_for('static', filename='images/default_avatar.png') }}" alt="Avatar" class="rounded-circle me-3" width="50" height="50">
+            <img src="{{ user.profile_picture_url or url_for('static', filename='images/default_avatar.png') }}" alt="Avatar" class="rounded-circle me-3" width="40" height="40">
             <input type="text" class="form-control me-2" placeholder="¿Qué estás estudiando?" readonly>
             {% if current_user.is_authenticated %}
-            <a href="{{ url_for('note.upload_note') }}" class="btn btn-dark ms-auto"><i class="fas fa-upload me-1"></i>Subir Apunte</a>
+            <a href="{{ url_for('note.upload_note') }}" class="btn btn-primary ms-auto"><i class="fas fa-upload me-1"></i>Subir</a>
             {% endif %}
         </div>
     </div>
-</div>
 
-<h2 class="mb-3">📄 Últimos Apuntes</h2>
-<div class="feed">
+    <h2 class="fw-bold mb-3">📄 Últimos Apuntes</h2>
+
+    <div class="feed">
     {% for note in notes %}
-    <div class="card mb-4 shadow-sm rounded">
-        <div class="card-body">
-            <div class="row g-0">
-                  <div class="col-md-2 d-flex align-items-center justify-content-center">
-                    {% if note.file_type == 'pdf' %}
-                          <embed src="{{ note.file_url }}#page=1" type="application/pdf" width="80" height="100" class="rounded border" style="object-fit: cover;" />
-                    {% elif note.file_url and note.file_type in ['jpg', 'jpeg', 'png'] %}
-                          <img src="{{ note.file_url }}" class="img-fluid rounded" style="max-height:100px; object-fit: cover;" alt="{{ note.title }}">
-                    {% else %}
-                        <i class="far fa-file-alt fa-3x text-muted"></i>
-                    {% endif %}
+    <article class="note-card card">
+        <div class="note-image">
+            {% if note.file_type == 'pdf' %}
+                <embed src="{{ note.file_url }}#page=1" type="application/pdf" class="w-100" style="height:180px; object-fit:cover;" />
+            {% elif note.file_url and note.file_type in ['jpg', 'jpeg', 'png'] %}
+                <img src="{{ note.file_url }}" class="w-100" style="max-height:180px; object-fit:cover;" alt="{{ note.title }}">
+            {% else %}
+                <div class="text-center py-4">
+                    <i class="far fa-file-alt fa-3x text-muted"></i>
                 </div>
-                <div class="col-md-10">
-                      <h5 class="mb-1 d-flex align-items-center">{{ note.title }}
-                          {% if note.course %}
-                          <span class="badge bg-secondary ms-2">{{ note.course }}</span>
-                          {% endif %}
-                      </h5>
-                    <p class="mb-1 text-muted">
-                        Subido por {{ note.uploader.name }} – {{ note.uploader.career or 'Carrera' }}
-                    </p>
-                    <p class="mb-2">{{ note.description[:120] }}...</p>
-                    <div class="d-flex justify-content-between">
-                        <a href="{{ url_for('note.note_detail', note_id=note.id) }}" class="btn btn-sm btn-outline-dark">📄 Ver Apunte</a>
-                        <small class="text-muted align-self-center">{{ note.page_count or '?' }} páginas</small>
-                    </div>
-                </div>
-            </div>
+            {% endif %}
         </div>
-        <div class="card-footer bg-white d-flex flex-wrap justify-content-center gap-2">
+        <div class="card-body">
+            <h5 class="note-title mb-1">{{ note.title }}</h5>
+            {% if note.course %}
+            <span class="badge bg-secondary mb-2">{{ note.course }}</span>
+            {% endif %}
+            <p class="note-meta mb-1">Subido por {{ note.uploader.name }} – {{ note.uploader.career or 'Carrera' }}</p>
+            <p class="note-desc mb-2">{{ note.description[:120] }}...</p>
+            <div class="text-center mb-2">
+                <a href="{{ url_for('note.note_detail', note_id=note.id) }}" class="btn btn-primary">📄 Ver Apunte</a>
+            </div>
+            <p class="text-center text-muted mb-0">{{ note.page_count or '?' }} páginas</p>
+        </div>
+        <div class="note-actions card-footer bg-white">
             <button class="btn btn-sm btn-outline-secondary">❤️ Me gusta</button>
             <button class="btn btn-sm btn-outline-secondary">💬 Comentar</button>
             <button class="btn btn-sm btn-outline-secondary">🔖 Guardar</button>
             <a href="{{ url_for('note.download_note_file', note_id=note.id) }}" class="btn btn-sm btn-outline-primary">⬇️ Descargar</a>
             <button class="btn btn-sm btn-outline-secondary">📤 Compartir</button>
         </div>
-    </div>
+    </article>
 
     {% if loop.index % 3 == 0 %}
     <div class="card mb-4 shadow-sm">
@@ -74,5 +69,6 @@
     {% else %}
     <p>No hay apuntes disponibles.</p>
     {% endfor %}
+    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Resumen de cambios
- nuevo diseño responsive en `feed.html` con contenedor `feed-container` y tarjetas `note-card`
- estilos móviles en `custom_feed.css` usando `border-radius` y `box-shadow`
- se documentó la acción en `AGENTS.md`

## Pruebas realizadas
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844f36ef760832586cfcb95b5c3939c