### PR TITLE
[Fix] remove mobile side padding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,3 +125,15 @@ pytest -q
 - Pruebas:
   ✅ `pip install -r requirements.txt`
   ✅ `PYTHONPATH=. pytest -q`
+
+### [Fix] Eliminar espacio gris lateral en móviles (2025-06-08)
+
+- Modificados:
+  - `crunevo/templates/base.html`
+  - `crunevo/static/css/style.css`
+- Detalles:
+  - Se reemplazó el contenedor principal por `.container-fluid p-0` para quitar padding.
+  - Se añadieron reglas globales que eliminan márgenes y padding en móviles para `.container`, `.container-fluid` y `.feed-container`.
+- Pruebas:
+  ✅ `pip install -r requirements.txt`
+  ✅ `PYTHONPATH=. pytest -q crunevo/tests`

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -80,9 +80,24 @@ body {
 }
 
 @media (max-width: 768px) {
-    .container {
+    body, html {
         padding: 0 !important;
         margin: 0 !important;
-        max-width: 100vw !important;
+        width: 100vw !important;
+        overflow-x: hidden;
+    }
+
+    .container,
+    .container-fluid,
+    .feed-container {
+        padding-left: 0 !important;
+        padding-right: 0 !important;
+        margin-left: 0 !important;
+        margin-right: 0 !important;
+        width: 100vw !important;
+    }
+
+    .note-card {
+        border-radius: 0 !important;
     }
 }

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -23,7 +23,7 @@
       {% endif %}
     {% endwith %}
 
-    <div class="container main-container">
+    <div class="container-fluid p-0 main-container">
         {% block content %}{% endblock %}
     </div>
     <script src="{{ url_for('static', filename='js/bootstrap.bundle.min.js') }}"></script>


### PR DESCRIPTION
## Summary
- use `.container-fluid p-0` for main container
- override Bootstrap paddings and margins for small screens
- document fix in `AGENTS.md`

## Testing
- `black .`
- `PYTHONPATH=. pytest -q crunevo/tests`

------
https://chatgpt.com/codex/tasks/task_e_684500857e5c832588b0d6d60110de42