### PR TITLE
[Fix] Ajustes feed móvil y badges

### DIFF
--- a/crunevo/static/css/custom_feed.css
+++ b/crunevo/static/css/custom_feed.css
@@ -15,7 +15,7 @@
 
 .note-card {
     border-radius: var(--card-radius);
-    box-shadow: var(--card-shadow);
+    box-shadow: 0 2px 10px rgba(0,0,0,0.05);
     overflow: hidden;
     background: #fff;
     border: none;
@@ -45,19 +45,23 @@
 }
 
 .note-title {
-    font-weight: 600;
-    font-size: 1.4rem;
+    font-weight: 700;
+    font-size: 1.5rem;
+    margin-bottom: 0.3rem;
 }
 
 .note-desc {
     text-align: justify;
-    line-height: 1.5;
-    margin-bottom: 1rem;
+    line-height: 1.6;
+    font-size: 1rem;
+    color: #333;
+    margin-bottom: 0.8rem;
 }
 
 .note-meta {
-    font-size: 0.875rem;
-    color: #6c757d;
+    font-size: 0.85rem;
+    color: #666;
+    margin-bottom: 0.2rem;
 }
 
 .note-actions {
@@ -126,4 +130,17 @@
     .action-btn {
         font-size: 1rem;
     }
+    .note-card {
+        border-radius: 0 0 12px 12px;
+    }
+}
+
+.badge[data-facultad="Ciencias"] {
+    background-color: #007bff;
+}
+.badge[data-facultad="Educacion"] {
+    background-color: #28a745;
+}
+.badge[data-facultad="Humanidades"] {
+    background-color: #6f42c1;
 }

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -84,20 +84,34 @@ body {
         padding: 0 !important;
         margin: 0 !important;
         width: 100vw !important;
-        overflow-x: hidden;
+        overflow-x: hidden !important;
+        background: #fff !important;
     }
 
+    .main-container,
+    .feed-container,
+    .create-note,
+    .note-card,
     .container,
-    .container-fluid,
-    .feed-container {
-        padding-left: 0 !important;
-        padding-right: 0 !important;
-        margin-left: 0 !important;
-        margin-right: 0 !important;
+    .container-fluid {
+        padding: 0 !important;
+        margin: 0 !important;
         width: 100vw !important;
+        max-width: 100vw !important;
+        border-radius: 0 !important;
     }
 
-    .note-card {
-        border-radius: 0 !important;
+    .card-body,
+    .card-footer {
+        padding-left: 1rem !important;
+        padding-right: 1rem !important;
+    }
+
+    .note-image embed,
+    .note-image img {
+        width: 100vw !important;
+        height: auto;
+        display: block;
+        object-fit: cover;
     }
 }

--- a/crunevo/templates/feed.html
+++ b/crunevo/templates/feed.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 <div class="feed-container">
-    <div class="create-note card p-3 shadow-sm">
+    <div class="create-note card shadow-sm">
         <div class="d-flex align-items-center">
             <img
                 src="{{ user.profile_picture_url or
@@ -59,32 +59,28 @@
             {% endif %}
         </div>
         <div class="card-body">
-            <h5 class="note-title mb-1">{{ note.title }}</h5>
-            {% if note.course %}
-            <span class="badge bg-secondary mb-2">
-                <i class="fas fa-book-open me-1"></i>{{ note.course }}
-            </span>
-            {% endif %}
-            {% if note.faculty %}
-            <span class="badge bg-secondary mb-2">
-                <i class="fas fa-university me-1"></i>{{ note.faculty }}
-            </span>
-            {% endif %}
-            <p class="note-meta mb-1">
-                Subido por {{ note.uploader.name }} –
-                {{ note.uploader.career or 'Carrera' }}
-            </p>
-            <p class="note-desc mb-2">{{ note.description[:120] }}...</p>
-            <div class="text-center mb-2">
+            <h5 class="note-title">{{ note.title }}</h5>
+            <div class="mb-2">
                 <a
                     href="{{ url_for('note.note_detail', note_id=note.id) }}"
-                    class="btn btn-primary">
+                    class="btn btn-primary w-100 mb-2">
                     📄 Ver Apunte
                 </a>
             </div>
-            <p class="text-center text-muted mb-0">
-                {{ note.page_count or '?' }} páginas
+            <p class="note-meta mb-1">
+                <i class="fas fa-user-graduate me-1"></i>{{ note.uploader.name }} –
+                {{ note.uploader.career or 'Carrera' }}
             </p>
+            <p class="note-meta mb-1">{{ note.page_count or '?' }} páginas</p>
+            {% if note.faculty %}
+            <span class="badge text-white mb-1" data-facultad="{{ note.faculty }}">{{ note.faculty }}</span>
+            {% endif %}
+            {% if note.course %}
+            <span class="badge bg-secondary mb-1">
+                <i class="fas fa-book-open me-1"></i>{{ note.course }}
+            </span>
+            {% endif %}
+            <p class="note-desc">{{ note.description[:120] }}...</p>
         </div>
         <div class="note-actions card-footer bg-white d-flex justify-content-between">
             <button class="action-btn" aria-label="Me gusta">


### PR DESCRIPTION
## Summary
- tweak global mobile rules to remove side spacing
- refine feed card layout and badges
- style note cards with stronger headings and colored faculty tags

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q crunevo/tests`

------
https://chatgpt.com/codex/tasks/task_e_684504cf23f8832590b00c1ba826544f