### PR TITLE
[Refactor] improve mobile feed layout

### DIFF
--- a/crunevo/static/css/custom_feed.css
+++ b/crunevo/static/css/custom_feed.css
@@ -46,7 +46,8 @@
 
 .note-title {
     font-weight: 700;
-    font-size: 1.5rem;
+    font-size: 1.6rem !important;
+    margin-top: 0.5rem;
     margin-bottom: 0.3rem;
 }
 
@@ -54,8 +55,8 @@
     text-align: justify;
     line-height: 1.6;
     font-size: 1rem;
-    color: #333;
-    margin-bottom: 0.8rem;
+    color: #444;
+    margin-bottom: 1rem;
 }
 
 .note-meta {
@@ -90,7 +91,8 @@
 }
 
 .action-btn.active {
-    color: #0d6efd;
+    color: #0d6efd !important;
+    font-weight: bold;
 }
 
 .action-btn:hover {
@@ -122,7 +124,7 @@
         border-radius: 0;
     }
     .note-title {
-        font-size: 1.4rem;
+        font-size: 1.6rem !important;
     }
     .note-desc {
         font-size: 1rem;

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -99,6 +99,7 @@ body {
         width: 100vw !important;
         max-width: 100vw !important;
         border-radius: 0 !important;
+        background-color: #fff !important;
     }
 
     .card-body,
@@ -110,8 +111,9 @@ body {
     .note-image embed,
     .note-image img {
         width: 100vw !important;
-        height: auto;
-        display: block;
+        height: auto !important;
         object-fit: cover;
+        display: block;
+        border-radius: 0 !important;
     }
 }


### PR DESCRIPTION
## Summary
- polish mobile feed rules to remove margins and force edge-to-edge layout
- enlarge note titles and tweak descriptions
- highlight active action buttons

## Testing
- `black . --line-length 88`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68450f12759083258e0070a20dec87dd