### PR TITLE
[Fix] eliminar sombras y bordes en feed movil

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,3 +137,15 @@ pytest -q
 - Pruebas:
   ✅ `pip install -r requirements.txt`
   ✅ `PYTHONPATH=. pytest -q crunevo/tests`
+
+### [Fix] Eliminar sombras y bordes de tarjetas en móviles (2025-06-08)
+
+- Modificados:
+  - `crunevo/static/css/custom_feed.css`
+  - `crunevo/static/css/style.css`
+- Detalles:
+  - Se eliminaron `border-radius` y `box-shadow` de `.note-card` y `.create-note.card` en móviles.
+  - Regla global para `.card` en pantallas pequeñas evita sombras y bordes.
+- Pruebas:
+  ✅ `black .`
+  ❌ `PYTHONPATH=. pytest -q` (faltan dependencias)

--- a/crunevo/static/css/custom_feed.css
+++ b/crunevo/static/css/custom_feed.css
@@ -108,7 +108,14 @@
     .note-card {
         width: 100%;
         margin-bottom: 1rem;
-        border-radius: 0;
+        border-radius: 0 !important;
+        box-shadow: none !important;
+        border: none !important;
+    }
+    .create-note.card {
+        border-radius: 0 !important;
+        box-shadow: none !important;
+        border: none !important;
     }
     .create-note input.form-control {
         font-size: 0.9rem;
@@ -131,9 +138,6 @@
     }
     .action-btn {
         font-size: 1rem;
-    }
-    .note-card {
-        border-radius: 0 0 12px 12px;
     }
 }
 

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -107,6 +107,13 @@ body {
         padding-left: 1rem !important;
         padding-right: 1rem !important;
     }
+    .card {
+        box-shadow: none !important;
+        border: none !important;
+        margin: 0 !important;
+        padding: 0 !important;
+    }
+
 
     .note-image embed,
     .note-image img {


### PR DESCRIPTION
## Summary
- remove border radius and shadow for note cards in mobile
- add global `.card` rule with no shadow or border for mobile
- document changes in AGENTS

## Testing
- `black .`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6845114220f483258434280c70347087