### PR TITLE
[Refactor] Modernizar feed móvil

### DIFF
--- a/crunevo/static/css/custom_feed.css
+++ b/crunevo/static/css/custom_feed.css
@@ -3,22 +3,27 @@
     --card-shadow: 0 4px 8px rgba(0,0,0,0.1);
 }
 
+.feed-container .btn-primary {
+    background-color: #1877f2;
+    border-color: #1877f2;
+}
+
 .feed-container {
     width: 100%;
-    max-width: 900px;
-    margin: 0 auto;
-    padding: 1rem;
+    max-width: none;
+    margin: 0;
+    padding: 0;
     display: flex;
     flex-direction: column;
-    gap: 1rem;
 }
 
 .note-card {
-    border-radius: var(--card-radius);
-    box-shadow: 0 2px 10px rgba(0,0,0,0.05);
+    border-radius: 0;
+    box-shadow: none;
     overflow: hidden;
     background: #fff;
     border: none;
+    color: #050505;
 }
 
 .animate-fade {
@@ -47,8 +52,9 @@
 .note-title {
     font-weight: 700;
     font-size: 1.6rem !important;
-    margin-top: 0.5rem;
+    margin-top: 0.25rem;
     margin-bottom: 0.3rem;
+    color: #050505;
 }
 
 .note-desc {
@@ -61,25 +67,31 @@
 
 .note-meta {
     font-size: 0.85rem;
-    color: #666;
+    color: #6c757d;
     margin-bottom: 0.2rem;
+}
+
+.badge {
+    display: inline-block;
+    margin-right: 0.25rem;
+    border-radius: 999px;
+    color: #fff;
 }
 
 .note-actions {
     display: flex;
-    justify-content: space-between;
-    gap: 0.25rem;
+    flex-wrap: wrap;
     border-top: 1px solid #e0e0e0;
-    padding: 0.5rem;
+    padding: 0.5rem 0;
 }
 
 .action-btn {
-    flex: 1;
+    flex: 1 0 50%;
     border: none;
     background: transparent;
-    padding: 0.5rem 0;
-    font-size: 1rem;
-    color: #444;
+    padding: 0.75rem 0;
+    font-size: 0.9rem;
+    color: #050505;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -87,11 +99,11 @@
 }
 
 .action-btn i {
-    font-size: 1.3rem;
+    font-size: 1.2rem;
 }
 
 .action-btn.active {
-    color: #0d6efd !important;
+    color: #1877f2 !important;
     font-weight: bold;
 }
 
@@ -107,7 +119,7 @@
     }
     .note-card {
         width: 100%;
-        margin-bottom: 1rem;
+        margin: 0;
         border-radius: 0 !important;
         box-shadow: none !important;
         border: none !important;
@@ -137,7 +149,8 @@
         font-size: 1rem;
     }
     .action-btn {
-        font-size: 1rem;
+        font-size: 0.9rem;
+        flex-basis: 50%;
     }
 }
 

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -85,7 +85,7 @@ body {
         margin: 0 !important;
         width: 100vw !important;
         overflow-x: hidden !important;
-        background: #fff !important;
+        background: #f0f2f5 !important;
     }
 
     .main-container,
@@ -99,7 +99,7 @@ body {
         width: 100vw !important;
         max-width: 100vw !important;
         border-radius: 0 !important;
-        background-color: #fff !important;
+        background-color: #f0f2f5 !important;
     }
 
     .card-body,

--- a/crunevo/templates/feed.html
+++ b/crunevo/templates/feed.html
@@ -36,7 +36,6 @@
     </p>
     <h2 class="fw-bold mb-3">📄 Últimos Apuntes</h2>
 
-    <div class="feed">
     {% for note in notes %}
     <article class="note-card card animate-fade">
         <div class="note-image">
@@ -60,15 +59,13 @@
         </div>
         <div class="card-body">
             <h5 class="note-title">{{ note.title }}</h5>
-            <div class="mb-2">
-                <a
-                    href="{{ url_for('note.note_detail', note_id=note.id) }}"
-                    class="btn btn-primary w-100 mb-2">
-                    📄 Ver Apunte
-                </a>
-            </div>
+            <a
+                href="{{ url_for('note.note_detail', note_id=note.id) }}"
+                class="btn btn-primary w-100 mt-2 mb-2">
+                📄 Ver Apunte
+            </a>
             <p class="note-meta mb-1">
-                <i class="fas fa-user-graduate me-1"></i>{{ note.uploader.name }} –
+                <i class="fas fa-user me-1"></i>{{ note.uploader.name }} –
                 {{ note.uploader.career or 'Carrera' }}
             </p>
             <p class="note-meta mb-1">{{ note.page_count or '?' }} páginas</p>
@@ -120,6 +117,5 @@
     {% else %}
     <p>No hay apuntes disponibles.</p>
     {% endfor %}
-    </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Resumen de cambios
- eliminar contenedor extra en el feed
- ajustar estilos del feed para ocupar todo el ancho en móviles
- rediseñar encabezado y acciones con color azul Facebook
- unificar badges y colores
- fondo general gris claro y tarjetas sin sombra

## Pruebas realizadas
- `black . --line-length 88`
- `pytest -q` *(fallan dependencias)*

------
https://chatgpt.com/codex/tasks/task_e_684517e65b80832588c9c42054243736