### PR TITLE
[Enhancement] mejoras en feed y dark mode

### DIFF
--- a/crunevo/static/css/custom_feed.css
+++ b/crunevo/static/css/custom_feed.css
@@ -31,6 +31,7 @@
     border: none;
     color: #050505;
     transition: transform 0.2s ease-in-out;
+    animation: fadeUp 0.4s ease-in-out;
 }
 
 .note-card:hover {
@@ -195,4 +196,15 @@
 }
 .badge[data-facultad="Humanidades"] {
     background-color: #6f42c1;
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background: #18191a;
+        color: #e4e6eb;
+    }
+    .note-card {
+        background: #242526;
+        color: #e4e6eb;
+    }
 }

--- a/crunevo/templates/feed.html
+++ b/crunevo/templates/feed.html
@@ -84,10 +84,10 @@
         <div class="note-actions card-footer bg-white">
             <div class="action-row d-flex">
                 <button class="action-btn" data-action="like" aria-label="Me gusta">
-                    <i class="fas fa-heart me-1"></i>Me gusta
+                    <i class="fas fa-heart me-1"></i> Me gusta <small>(3)</small>
                 </button>
                 <button class="action-btn" data-action="comment" aria-label="Comentar">
-                    <i class="fas fa-comment me-1"></i>Comentar
+                    <i class="fas fa-comment me-1"></i> Comentar <small>(2)</small>
                 </button>
                 <button class="action-btn" data-action="save" aria-label="Guardar">
                     <i class="fas fa-bookmark me-1"></i>Guardar
@@ -109,7 +109,7 @@
     </article>
 
     {% if loop.index % 3 == 0 %}
-    <div class="note-card text-center p-3 bg-light">
+    <div class="note-card text-center p-3 bg-light" onclick="location.href='/tienda'">
         🎓 ¿Sabías que puedes ganar puntos subiendo apuntes?
     </div>
     {% endif %}


### PR DESCRIPTION
## Summary
- animate note cards by default
- show placeholder counters for likes and comments
- make tip card clickable
- prepare CSS for dark mode support

## Testing
- `black . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68451f2cb2e483259fa7028e746bd8ae