### PR TITLE
[Fix] estilos desktop para feed

### DIFF
--- a/crunevo/static/css/custom_feed.css
+++ b/crunevo/static/css/custom_feed.css
@@ -198,6 +198,64 @@
     background-color: #6f42c1;
 }
 
+/* === SOLO PARA PANTALLAS GRANDES === */
+@media (min-width: 992px) {
+    .feed-container {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 2rem 1rem;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
+    }
+
+    .note-card {
+        border-radius: 0.75rem;
+        box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+        margin-bottom: 1.5rem;
+        transition: transform 0.2s ease-in-out;
+    }
+
+    .note-card:hover {
+        transform: scale(1.01);
+    }
+
+    .note-title {
+        font-size: 1.6rem !important;
+        line-height: 1.4;
+    }
+
+    .note-desc {
+        font-size: 1rem;
+        line-height: 1.6;
+        text-align: justify;
+        margin-top: 0.5rem;
+    }
+
+    .note-actions {
+        flex-direction: row;
+        justify-content: space-between;
+        padding: 0.75rem 1rem;
+        border-top: 1px solid #e0e0e0;
+    }
+
+    .note-actions .action-row {
+        flex: 1;
+        justify-content: space-evenly;
+    }
+
+    .action-btn {
+        font-size: 0.95rem;
+        padding: 0.5rem 1rem;
+        border-radius: 0.375rem;
+    }
+
+    .badge {
+        font-size: 0.8rem;
+        padding: 0.35rem 0.75rem;
+    }
+}
+
 @media (prefers-color-scheme: dark) {
     body {
         background: #18191a;


### PR DESCRIPTION
## Resumen de cambios
- agregados estilos exclusivos para pantallas grandes en `custom_feed.css`

## Pruebas realizadas
- `black .`
- `pytest -q` *(falló: ModuleNotFoundError por dependencias faltantes)*

------
https://chatgpt.com/codex/tasks/task_e_684522bcf4cc8325badf315db039a622