### PR TITLE
[Feat] Feed centrado en desktop

### DIFF
--- a/crunevo/static/css/custom_feed.css
+++ b/crunevo/static/css/custom_feed.css
@@ -196,3 +196,46 @@
 .badge[data-facultad="Humanidades"] {
     background-color: #6f42c1;
 }
+/* === Diseño Desktop centrado con espacio lateral === */
+@media (min-width: 992px) {
+  body {
+    background-color: #f0f2f5 !important;
+  }
+
+  .main-container {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    gap: 2rem;
+    padding: 2rem 1rem;
+  }
+
+  .sidebar-left,
+  .sidebar-right {
+    flex: 1;
+    min-width: 100px;
+    max-width: 220px;
+  }
+
+  .feed-container {
+    flex: 0 0 860px;
+    background: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+    padding: 1.5rem 2rem;
+  }
+
+  .note-card {
+    border-radius: 0.75rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .note-actions {
+    justify-content: space-between;
+  }
+
+  .badge {
+    font-size: 0.8rem;
+    padding: 0.4rem 0.8rem;
+  }
+}

--- a/crunevo/templates/feed.html
+++ b/crunevo/templates/feed.html
@@ -7,7 +7,10 @@
 {% endblock %}
 
 {% block content %}
-<div class="feed-container">
+<div class="main-container">
+  <div class="sidebar-left d-none d-lg-block"></div>
+
+  <div class="feed-container">
     <div class="create-note card shadow-sm">
         <div class="d-flex align-items-center">
             <img
@@ -116,5 +119,7 @@
     {% else %}
     <p>No hay apuntes disponibles.</p>
     {% endfor %}
+  </div>
+  <div class="sidebar-right d-none d-lg-block"></div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Resumen de cambios
- Envolver el feed con `main-container` y sidebars laterales
- Añadir estilos responsive para centrar el feed en pantallas grandes

## Pruebas realizadas
- `black .`
- `pytest -q` *(fallan dependencias)*

------
https://chatgpt.com/codex/tasks/task_e_6845261e5d688325ba5d69d4d5f4dbc3