### PR TITLE
[Fix] Configure PostgreSQL requirements

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-SQLALCHEMY_DATABASE_URI=postgresql://user:password@localhost:5432/crunevo
+SQLALCHEMY_DATABASE_URI=${DATABASE_URL}
 
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ Crunevo is a small Flask application. The source code lives in the `crunevo/` fo
 
 The application now relies on PostgreSQL in production. Set the environment
 variable `SQLALCHEMY_DATABASE_URI` with the connection string provided by your
-hosting platform (for example Railway). The selected URI is printed on startup
-for verification.
+hosting platform (for example Railway).
 
 Define `SQLALCHEMY_DATABASE_URI` directly with your PostgreSQL URL.
 

--- a/crunevo/config.py
+++ b/crunevo/config.py
@@ -11,8 +11,6 @@ class Config:
     SQLALCHEMY_TRACK_MODIFICATIONS = False
     DEBUG = os.getenv("DEBUG", "0") == "1"
 
-    print(f"Using database URI: {SQLALCHEMY_DATABASE_URI}")
-
     NOTE_UPLOAD_FOLDER = os.getenv(
         "NOTE_UPLOAD_FOLDER",
         str(Path(__file__).resolve().parent / "static" / "uploads" / "notes"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ boto3==1.34.121
 gunicorn==21.2.0
 email-validator==2.2.0
 Flask-Migrate==4.1.0
+psycopg2-binary==2.9.9


### PR DESCRIPTION
## Summary
- add psycopg2-binary to requirements
- point SQLALCHEMY_DATABASE_URI to DATABASE_URL in `.env`

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q crunevo/tests`
- `black .`

------
https://chatgpt.com/codex/tasks/task_e_684546c8b6bc8325b00c3366c924c0b0