### PR TITLE
[Fix] Load .env from project root

### DIFF
--- a/crunevo/config.py
+++ b/crunevo/config.py
@@ -2,7 +2,8 @@ import os
 from pathlib import Path
 from dotenv import load_dotenv
 
-load_dotenv()
+BASE_DIR = Path(__file__).resolve().parent.parent
+load_dotenv(BASE_DIR / ".env")
 
 
 class Config:


### PR DESCRIPTION
## Summary
- load environment variables from the project root `.env`

## Testing
- `black .`
- `PYTHONPATH=. pytest -q crunevo/tests`


------
https://chatgpt.com/codex/tasks/task_e_6845ed4801288325b6a88f4cdbbd365b