### PR TITLE
[Fix] improve profile page and tests

### DIFF
--- a/crunevo/static/css/profile.css
+++ b/crunevo/static/css/profile.css
@@ -1,0 +1,37 @@
+.container-profile {
+    max-width: 960px;
+    margin: 0 auto;
+}
+.profile-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1rem;
+}
+.profile-avatar {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+.profile-stats .stat-card {
+    border: none;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    transition: transform 0.2s;
+}
+.profile-stats .stat-card:hover {
+    transform: translateY(-4px);
+}
+.profile-activity ul {
+    max-height: 300px;
+    overflow-y: auto;
+}
+@media (max-width: 768px) {
+    .profile-header {
+        justify-content: center;
+        text-align: center;
+    }
+    .profile-actions {
+        flex-direction: column;
+    }
+}

--- a/crunevo/templates/perfil.html
+++ b/crunevo/templates/perfil.html
@@ -1,9 +1,134 @@
 {% extends 'base.html' %}
-{% block title %}Mi Perfil - CRUNEVO{% endblock %}
+{% block title %}Mi Perfil{% endblock %}
+{% block head_extra %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/profile.css') }}">
+{% endblock %}
 {% block content %}
-<h2>Perfil de {{ current_user.username }}</h2>
-<p><strong>Email:</strong> {{ current_user.email }}</p>
-<p><strong>Rol:</strong> {{ current_user.role }}</p>
-<p><strong>Créditos:</strong> {{ current_user.creditos }}</p>
-<a href="{{ url_for('main.index') }}">Volver al inicio</a>
+<div class="container-profile my-4">
+  <div class="profile-header">
+    <div class="position-relative">
+      <img src="{{ user.profile_picture_url or url_for('static', filename='images/default_avatar.png') }}" class="profile-avatar" id="profileAvatarImage" alt="Foto de perfil">
+      <button class="btn btn-sm btn-light position-absolute bottom-0 end-0 edit-avatar-btn"><i class="fas fa-camera"></i></button>
+      <input type="file" id="avatarInput" accept="image/*" class="d-none">
+      {# TODO: validate avatar size with MAX_AVATAR_SIZE_MB and secure_filename #}
+    </div>
+    <div>
+      <h2 class="fw-bold mb-0">{{ user.name }}</h2>
+      <p class="text-muted mb-1">{{ user.email }}</p>
+      {% if user.role == 'admin' %}
+        <span class="badge bg-secondary">⚙️ Administrador</span>
+      {% else %}
+        <span class="badge bg-primary">🎓 Estudiante</span>
+      {% endif %}
+      <p class="mt-2">📘 {{ user.career }} — {{ user.faculty }}</p>
+    </div>
+  </div>
+
+  <div class="profile-stats row text-center mt-4 g-3">
+    <div class="col-6 col-md-4">
+      <div class="card stat-card">
+        <div class="card-body">
+          <div class="h4">{{ user_stats.notes_uploaded }}</div>
+          <small>Apuntes subidos</small>
+        </div>
+      </div>
+    </div>
+    <div class="col-6 col-md-4">
+      <div class="card stat-card">
+        <div class="card-body">
+          <div class="h4">{{ user_stats.downloads_total }}</div>
+          <small>Descargas totales</small>
+        </div>
+      </div>
+    </div>
+    <div class="col-6 col-md-4">
+      <div class="card stat-card">
+        <div class="card-body">
+          <div class="h4">{{ user_stats.likes_received }}</div>
+          <small>Likes recibidos</small>
+        </div>
+      </div>
+    </div>
+    <div class="col-6 col-md-4">
+      <div class="card stat-card">
+        <div class="card-body">
+          <div class="h4">{{ user_stats.responses_count }}</div>
+          <small>Respuestas foro</small>
+        </div>
+      </div>
+    </div>
+    <div class="col-6 col-md-4">
+      <div class="card stat-card">
+        <div class="card-body">
+          <div class="h4">{{ user_stats.points }}</div>
+          <small>Puntos</small>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="progress mt-3">
+    <div class="progress-bar" role="progressbar" style="width: {{ user_stats.points or 0 }}%;" aria-valuenow="{{ user_stats.points or 0 }}" aria-valuemin="0" aria-valuemax="1000">
+      {{ user_stats.points or 0 }} pts
+    </div>
+  </div>
+
+  <div class="profile-activity mt-4">
+    <h4>Actividad reciente</h4>
+    <ul class="list-group">
+      {% for event in events %}
+        <li class="list-group-item">{{ event.message }}</li>
+      {% else %}
+        <li class="list-group-item text-muted">Sin actividad reciente.</li>
+      {% endfor %}
+    </ul>
+  </div>
+
+  <div class="profile-actions mt-4 d-flex flex-wrap gap-2">
+    <a href="{{ url_for('user.edit_profile') }}" class="btn btn-outline-primary flex-fill">✍️ Editar perfil</a>
+    <a href="{{ url_for('note.upload_note') }}" class="btn btn-outline-success flex-fill">📤 Subir apunte</a>
+    <a href="{{ url_for('store.tienda') }}" class="btn btn-outline-info flex-fill">🛒 Mis productos</a>
+    {% if user.chat_enabled %}
+    <a href="{{ url_for('chat.chat') }}" class="btn btn-outline-secondary flex-fill">💬 Mensajes</a>
+    {% endif %}
+    {% if user.role == 'admin' %}
+    <a href="{{ url_for('admin.dashboard') }}" class="btn btn-outline-danger flex-fill">⚙️ Panel admin</a>
+    {% endif %}
+  </div>
+
+  <div class="mt-4">
+    <div class="card">
+      <div class="card-body">
+        Créditos actuales: {{ user.credits }}
+        <div class="mt-2">
+          <button class="btn btn-sm btn-primary me-2">Agregar</button>
+          <button class="btn btn-sm btn-secondary">Enviar</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="mt-4">
+    <h5>Privacidad</h5>
+    <div class="form-check form-switch">
+      <input class="form-check-input" type="checkbox" id="publicProfile" checked>
+      <label class="form-check-label" for="publicProfile">Mostrar mi perfil públicamente</label>
+    </div>
+    <div class="form-check form-switch">
+      <input class="form-check-input" type="checkbox" id="privateMsg" {% if user.chat_enabled %}checked{% endif %}>
+      <label class="form-check-label" for="privateMsg">Activar mensajes privados</label>
+    </div>
+    <div class="form-check form-switch">
+      <input class="form-check-input" type="checkbox" id="emailNotify" checked>
+      <label class="form-check-label" for="emailNotify">Recibir notificaciones por correo</label>
+    </div>
+  </div>
+</div>
+{% endblock %}
+{% block scripts %}
+<script>
+document.querySelector('.edit-avatar-btn')?.addEventListener('click', () => {
+    document.getElementById('avatarInput').click();
+});
+</script>
 {% endblock %}

--- a/crunevo/tests/test_user_profile.py
+++ b/crunevo/tests/test_user_profile.py
@@ -1,0 +1,59 @@
+import os
+import pytest
+from crunevo.app import create_app
+from crunevo.models import db
+from crunevo.models.user import User
+from crunevo.models.note import Note
+from crunevo.models.forum import Pregunta, Respuesta
+
+
+@pytest.fixture
+def app(tmp_path):
+    os.environ["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{tmp_path}/test.db"
+    application = create_app()
+    application.config["TESTING"] = True
+    application.config["WTF_CSRF_ENABLED"] = False
+    with application.app_context():
+        db.create_all()
+    return application
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def sample_user(app):
+    with app.app_context():
+        u = User(username="tester", email="tester@example.com")
+        u.set_password("secret")
+        db.session.add(u)
+        db.session.commit()
+        return u.id
+
+
+def login(client, email, password):
+    return client.post(
+        "/login", data={"email": email, "password": password}, follow_redirects=False
+    )
+
+
+def test_profile_page_shows_stats(client, app, sample_user):
+    with app.app_context():
+        uid = sample_user
+        n = Note(title="Algebra", file_url="/a.pdf", user_id=uid)
+        n.downloads_count = 3
+        n.likes_count = 2
+        db.session.add(n)
+        q = Pregunta(titulo="Metodo?", contenido="desc", autor_id=uid)
+        db.session.add(q)
+        r = Respuesta(contenido="respuesta", autor_id=uid, pregunta=q)
+        db.session.add(r)
+        db.session.commit()
+    login(client, "tester@example.com", "secret")
+    resp = client.get("/user/profile")
+    assert resp.status_code == 200
+    assert b"Apuntes subidos" in resp.data
+    assert b"Descargas totales" in resp.data
+    assert b"Algebra" in resp.data

--- a/crunevo/utils/activity_feed.py
+++ b/crunevo/utils/activity_feed.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""Utility functions for building user activity feeds."""
+
+from typing import List, Dict
+
+
+def build_user_activity(user) -> List[Dict[str, object]]:
+    """Return a sorted list of activity events for the given user."""
+    events = []
+
+    for note in getattr(user, "notes", []):
+        events.append(
+            {
+                "timestamp": note.upload_date,
+                "message": f'📤 Subiste el apunte "{note.title}"',
+            }
+        )
+        if note.downloads_count:
+            events.append(
+                {
+                    "timestamp": note.upload_date,
+                    "message": f'⬇️ Tu apunte "{note.title}" fue descargado {note.downloads_count} veces',
+                }
+            )
+
+    for r in getattr(user, "respuestas", []):
+        if r.pregunta:
+            events.append(
+                {
+                    "timestamp": r.fecha,
+                    "message": f'💬 Respondiste a la pregunta "{r.pregunta.titulo}"',
+                }
+            )
+
+    for p in getattr(user, "posts", []):
+        events.append(
+            {"timestamp": p.timestamp, "message": "📢 Publicaste una actualización"}
+        )
+
+    events.sort(key=lambda e: e["timestamp"], reverse=True)
+    return events


### PR DESCRIPTION
## Summary
- fix emoji encodings and move activity generation to utils
- add progress bar and privacy comment to profile template
- create test to verify profile stats and activity

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q crunevo/tests`


------
https://chatgpt.com/codex/tasks/task_e_6846242da3088325a225b8b1ec9ae242