### PR TITLE
[Feat] Enhance user profile activity feed

### DIFF
--- a/crunevo/templates/perfil.html
+++ b/crunevo/templates/perfil.html
@@ -66,6 +66,12 @@
     </div>
   </div>
 
+  <div class="progress mt-3">
+    <div class="progress-bar" role="progressbar" style="width: {{ user_stats.points or 0 }}%;" aria-valuenow="{{ user_stats.points or 0 }}" aria-valuemin="0" aria-valuemax="1000">
+      {{ user_stats.points or 0 }} pts
+    </div>
+  </div>
+
   <div class="profile-activity mt-4">
     <h4>Actividad reciente</h4>
     <ul class="list-group">

--- a/crunevo/tests/test_user_profile.py
+++ b/crunevo/tests/test_user_profile.py
@@ -1,0 +1,59 @@
+import os
+import pytest
+from crunevo.app import create_app
+from crunevo.models import db
+from crunevo.models.user import User
+from crunevo.models.note import Note
+from crunevo.models.forum import Pregunta, Respuesta
+
+
+@pytest.fixture
+def app(tmp_path):
+    os.environ["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{tmp_path}/test.db"
+    application = create_app()
+    application.config["TESTING"] = True
+    application.config["WTF_CSRF_ENABLED"] = False
+    with application.app_context():
+        db.create_all()
+    return application
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def sample_user(app):
+    with app.app_context():
+        u = User(username="tester", email="tester@example.com")
+        u.set_password("secret")
+        db.session.add(u)
+        db.session.commit()
+        return u.id
+
+
+def login(client, email, password):
+    return client.post(
+        "/login", data={"email": email, "password": password}, follow_redirects=False
+    )
+
+
+def test_profile_page_shows_stats(client, app, sample_user):
+    with app.app_context():
+        uid = sample_user
+        n = Note(title="Algebra", file_url="/a.pdf", user_id=uid)
+        n.downloads_count = 3
+        n.likes_count = 2
+        db.session.add(n)
+        q = Pregunta(titulo="Metodo?", contenido="desc", autor_id=uid)
+        db.session.add(q)
+        r = Respuesta(contenido="respuesta", autor_id=uid, pregunta=q)
+        db.session.add(r)
+        db.session.commit()
+    login(client, "tester@example.com", "secret")
+    resp = client.get("/user/profile")
+    assert resp.status_code == 200
+    assert b"Apuntes subidos" in resp.data
+    assert b"Descargas totales" in resp.data
+    assert b"Algebra" in resp.data

--- a/crunevo/utils/activity_feed.py
+++ b/crunevo/utils/activity_feed.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+"""Utility functions for building user activity feeds."""
+
+from typing import List, Dict
+
+
+def build_user_activity(user) -> List[Dict[str, object]]:
+    """Return a sorted list of activity events for the given user."""
+    events = []
+
+    for note in getattr(user, "notes", []):
+        events.append(
+            {
+                "timestamp": note.upload_date,
+                "message": f'📤 Subiste el apunte "{note.title}"',
+            }
+        )
+        if note.downloads_count:
+            events.append(
+                {
+                    "timestamp": note.upload_date,
+                    "message": f'⬇️ Tu apunte "{note.title}" fue descargado {note.downloads_count} veces',
+                }
+            )
+
+    for r in getattr(user, "respuestas", []):
+        if r.pregunta:
+            events.append(
+                {
+                    "timestamp": r.fecha,
+                    "message": f'💬 Respondiste a la pregunta "{r.pregunta.titulo}"',
+                }
+            )
+
+    for p in getattr(user, "posts", []):
+        events.append(
+            {"timestamp": p.timestamp, "message": "📢 Publicaste una actualización"}
+        )
+
+    events.sort(key=lambda e: e["timestamp"], reverse=True)
+    return events


### PR DESCRIPTION
## Summary
- generate activity feed using helper
- add progress bar to profile template
- style user activity data
- test profile statistics

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462c46dcf08325ba9fcf265e79b503