### PR TITLE
[Feat] Modal upload with autocomplete tags

### DIFF
--- a/crunevo/routes/note_routes.py
+++ b/crunevo/routes/note_routes.py
@@ -161,6 +161,7 @@ def quick_note():
     title = request.form.get("title", "").strip()
     description = request.form.get("description", "").strip()
     categoria = request.form.get("categoria", "").strip()
+    tags = request.form.get("tags", "").strip()
     note_file = request.files.get("file")
 
     if not title or not note_file:
@@ -186,6 +187,7 @@ def quick_note():
         user_id=current_user.id,
         course=categoria,
         faculty=categoria,
+        tags=tags,
         upload_date=datetime.utcnow(),
     )
 

--- a/crunevo/static/css/custom_feed.css
+++ b/crunevo/static/css/custom_feed.css
@@ -302,3 +302,20 @@
   max-height: 200px;
   border-radius: 8px;
 }
+
+.modal.fade .modal-dialog {
+  transform: translateY(30px);
+  transition: transform 0.3s ease, opacity 0.3s ease;
+}
+.modal.fade.show .modal-dialog {
+  transform: translateY(0);
+}
+.was-validated .form-control:invalid {
+  border-color: #dc3545;
+  animation: blink 0.3s 2;
+}
+@keyframes blink {
+  50% {
+    border-color: #f5c6cb;
+  }
+}

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -310,21 +310,136 @@ document.addEventListener("DOMContentLoaded", () => {
 });
 
 document.addEventListener("DOMContentLoaded", () => {
-  document.querySelectorAll(".toggle-tabs .btn").forEach((btn) => {
-    btn.addEventListener("click", () => {
-      const mode = btn.dataset.mode;
-      document
-        .getElementById("mode-apunte")
-        .classList.toggle("d-none", mode !== "apunte");
-      document
-        .getElementById("mode-post")
-        .classList.toggle("d-none", mode !== "post");
-      document
-        .querySelectorAll(".toggle-tabs .btn")
-        .forEach((b) => b.classList.remove("active"));
-      btn.classList.add("active");
+  const openNoteBtn = document.getElementById("openNoteModalBtn");
+  const noteModalEl = document.getElementById("uploadNoteModal");
+  const noteForm = document.getElementById("noteForm");
+  const tagInput = document.getElementById("note-tags");
+  const tagSuggestions = [
+    "álgebra",
+    "álgebra lineal",
+    "derivadas",
+    "integrales",
+    "ecuaciones diferenciales",
+    "geometría analítica",
+    "trigonometría",
+    "límites",
+    "matrices",
+    "probabilidad",
+    "estadística",
+    "combinatoria",
+    "números complejos",
+    "fórmulas matemáticas",
+    "lógica matemática",
+    "física clásica",
+    "cinemática",
+    "leyes de Newton",
+    "ondas",
+    "termodinámica",
+    "química orgánica",
+    "química inorgánica",
+    "tabla periódica",
+    "reacciones químicas",
+    "enlaces químicos",
+    "biología celular",
+    "genética",
+    "anatomía",
+    "evolución",
+    "microbiología",
+    "historia del Perú",
+    "historia universal",
+    "revolución francesa",
+    "independencia de América",
+    "filosofía moderna",
+    "ética",
+    "ciudadanía",
+    "derechos humanos",
+    "arte precolombino",
+    "historia del arte",
+    "psicología",
+    "sociología",
+    "antropología",
+    "redacción",
+    "ortografía",
+    "tipos de texto",
+    "análisis literario",
+    "figuras literarias",
+    "comprensión lectora",
+    "técnicas de exposición",
+    "ensayos",
+    "argumentación",
+    "citas APA",
+    "referencias bibliográficas",
+    "programación",
+    "pseudocódigo",
+    "Python",
+    "HTML",
+    "CSS",
+    "JavaScript",
+    "redes",
+    "algoritmos",
+    "base de datos",
+    "ciberseguridad",
+    "sistemas operativos",
+    "informática educativa",
+    "Excel",
+    "resumen",
+    "apuntes",
+    "separata",
+    "práctica resuelta",
+    "solución paso a paso",
+    "clase grabada",
+    "guía de estudio",
+    "tips de examen",
+    "examen anterior",
+    "ciclo regular",
+    "sustitutorio",
+    "exoneración",
+    "educación inicial",
+    "educación secundaria",
+    "matemáticas y física",
+    "ingeniería industrial",
+    "derecho",
+    "medicina humana",
+    "enfermería",
+    "contabilidad",
+    "administración",
+    "psicología",
+    "arquitectura",
+    "agronomía",
+    "UNMSM",
+    "La Cantuta",
+    "San Marcos",
+    "UNI",
+    "CEPRE",
+    "EBA",
+    "CEBA",
+    "simulacro",
+    "preuniversitario",
+    "resumen gráfico",
+    "infografía",
+    "cuadro comparativo",
+    "mapa mental",
+    "ficha técnica",
+    "esquema",
+    "línea de tiempo",
+    "guía de laboratorio",
+    "rúbrica",
+    "portafolio",
+  ];
+
+  let noteModal;
+  if (openNoteBtn && noteModalEl) {
+    noteModal = new bootstrap.Modal(noteModalEl);
+    openNoteBtn.addEventListener("click", () => noteModal.show());
+  }
+
+  let tagify;
+  if (tagInput) {
+    tagify = new Tagify(tagInput, {
+      whitelist: tagSuggestions,
+      dropdown: { maxItems: 20, enabled: 0, closeOnSelect: false },
     });
-  });
+  }
 
   const imageInput = document.querySelector('input[name="image"]');
   if (imageInput) {
@@ -341,32 +456,54 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-  const form = document.getElementById("postForm");
-  form.addEventListener("submit", async (e) => {
-    e.preventDefault();
-    const activeMode = document.querySelector(".toggle-tabs .btn.active").dataset
-      .mode;
-    const url = activeMode === "apunte" ? "/quick_note" : "/crear_post";
-    const formData = new FormData(form);
-    try {
-      const resp = await fetch(url, {
-        method: "POST",
-        body: formData,
-        headers: { "X-Requested-With": "XMLHttpRequest" },
-      });
-      if (!resp.ok) throw new Error("error");
-      const data = await resp.json();
-      if (activeMode === "post") {
+  const postForm = document.getElementById("postForm");
+  if (postForm) {
+    postForm.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      const formData = new FormData(postForm);
+      try {
+        const resp = await fetch("/crear_post", {
+          method: "POST",
+          body: formData,
+          headers: { "X-Requested-With": "XMLHttpRequest" },
+        });
+        if (!resp.ok) throw new Error("error");
+        const data = await resp.json();
         addPostToFeed(data.post);
-      } else {
-        addNoteToFeed(data.note);
+        postForm.reset();
+        document.querySelector(".preview-img").innerHTML = "";
+      } catch (err) {
+        alert("Ocurrió un error al publicar");
       }
-      form.reset();
-      document.querySelector(".preview-img").innerHTML = "";
-    } catch (err) {
-      alert("Ocurrió un error al publicar");
-    }
-  });
+    });
+  }
+
+  if (noteForm) {
+    noteForm.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      if (!noteForm.checkValidity()) {
+        noteForm.classList.add("was-validated");
+        return;
+      }
+      const formData = new FormData(noteForm);
+      try {
+        const resp = await fetch("/quick_note", {
+          method: "POST",
+          body: formData,
+          headers: { "X-Requested-With": "XMLHttpRequest" },
+        });
+        if (!resp.ok) throw new Error("error");
+        const data = await resp.json();
+        addNoteToFeed(data.note);
+        noteForm.reset();
+        if (tagify) tagify.removeAllTags();
+        if (noteModal) noteModal.hide();
+        showToast("✅ Apunte subido con éxito");
+      } catch (err) {
+        alert("Ocurrió un error al publicar");
+      }
+    });
+  }
 
   function addPostToFeed(post) {
     const container = document.querySelector(".feed-container");

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -26,6 +26,7 @@
     <div class="container-fluid p-0 main-container">
         {% block content %}{% endblock %}
     </div>
+    {% include 'components/toast.html' %}
     <script src="{{ url_for('static', filename='js/bootstrap.bundle.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
     {% block scripts %}{% endblock %}

--- a/crunevo/templates/feed.html
+++ b/crunevo/templates/feed.html
@@ -4,6 +4,7 @@
 
 {% block head_extra %}
 <link rel="stylesheet" href="{{ url_for('static', filename='css/custom_feed.css') }}">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@yaireo/tagify/dist/tagify.css">
 {% endblock %}
 
 {% block content %}
@@ -12,25 +13,13 @@
 
   <div class="feed-container">
     <div class="post-toggle card shadow-sm p-3 mb-3">
-      <div class="toggle-tabs d-flex mb-2">
-        <button class="btn btn-outline-primary me-2 active" data-mode="apunte">📄 Subir Apunte</button>
+      <div class="d-flex mb-2">
+        <button id="openNoteModalBtn" class="btn btn-primary me-2">📄 Subir Apunte</button>
         <button class="btn btn-outline-secondary" data-mode="post">🗨️ Publicar Texto</button>
       </div>
 
       <form id="postForm" enctype="multipart/form-data">
-        <div id="mode-apunte">
-          <input type="text" name="title" class="form-control mb-2" placeholder="Título del apunte" required>
-          <textarea name="description" class="form-control mb-2" rows="2" placeholder="Descripción o resumen opcional"></textarea>
-          <input type="file" name="file" accept=".pdf" class="form-control mb-2" required>
-          <select name="categoria" class="form-select mb-2">
-            <option value="" disabled selected>Selecciona una categoría</option>
-            <option value="matematicas">Matemáticas</option>
-            <option value="historia">Historia</option>
-            <option value="otros">Otros</option>
-          </select>
-        </div>
-
-        <div id="mode-post" class="d-none">
+        <div id="mode-post">
           <textarea name="content" class="form-control mb-2" rows="3" placeholder="Comparte una idea, resumen o duda académica..."></textarea>
           <input type="file" name="image" accept="image/*" class="form-control mb-2">
           <div class="preview-img mt-2"></div>
@@ -139,4 +128,37 @@
   </div>
   <div class="sidebar-right d-none d-lg-block"></div>
 </div>
+
+<!-- Modal de subida de apunte -->
+<div class="modal fade" id="uploadNoteModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Subir Apunte</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+      </div>
+      <form id="noteForm" action="{{ url_for('note.quick_note') }}" method="POST" enctype="multipart/form-data">
+        <div class="modal-body">
+          <input type="text" name="title" class="form-control mb-2" placeholder="Título del apunte" required>
+          <textarea name="description" class="form-control mb-2" rows="2" placeholder="Descripción o resumen opcional"></textarea>
+          <input type="text" name="categoria" class="form-control mb-2" placeholder="Curso o categoría">
+          <input type="file" name="file" accept="application/pdf" class="form-control mb-2" required>
+          <input id="note-tags" name="tags" class="form-control mb-2" placeholder="Etiquetas">
+          <div class="form-check mb-2">
+            <input class="form-check-input" type="checkbox" value="1" id="termsCheck" name="terms" required title="Confirmo que tengo permiso para compartir este material.\nNo infringe derechos de autor.\nEste material es educativo o de dominio público.">
+            <label class="form-check-label" for="termsCheck">✅ Acepto los Términos y Condiciones</label>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="submit" class="btn btn-primary w-100">📤 Publicar Apunte</button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/@yaireo/tagify"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- trigger modal to upload notes from feed
- add tag suggestions via Tagify
- handle new tags in backend quick_note route
- include toast component globally
- style modal transitions and validation

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError for flask)*

------
https://chatgpt.com/codex/tasks/task_e_6846390c412883258cb9977a57b199af