### PR TITLE
[Enhancement] tooltips y form upload unificado

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,3 +188,17 @@ pytest -q
 - Eliminado `db.create_all()` y `DATABASE_DIR`.
 - PostgreSQL gestionado vía `SQLALCHEMY_DATABASE_URI` en Railway.
 - Se mantiene Flask-Migrate como gestor de cambios estructurales.
+
+
+### [Enhancement] Tooltip en aceptación de Términos (2025-06-09)
+- Modificados:
+  - `crunevo/templates/feed.html`
+  - `crunevo/templates/upload_note.html`
+  - `crunevo/static/js/main.js`
+- Detalles:
+  - Se añadió atributo `data-bs-toggle="tooltip"` con mensaje informativo.
+  - Se centralizó la inicialización del formulario de subida en `main.js`.
+  - Ahora se inicializan tooltips globalmente al cargar la página.
+- Pruebas:
+  ✅ `pip install -r requirements.txt`
+  ❌ `pytest -q` (faltan dependencias de entorno)

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -321,6 +321,12 @@ function initActionButtons() {
     });
 }
 
+function initTooltips() {
+  document
+    .querySelectorAll('[data-bs-toggle="tooltip"]')
+    .forEach((el) => new bootstrap.Tooltip(el));
+}
+
 function initTagify(selector) {
   const el = typeof selector === "string" ? document.querySelector(selector) : selector;
   if (!el) return null;
@@ -368,6 +374,35 @@ function initFeedForms() {
 
   const tagify = initTagify(tagInput);
   initImagePreview("#uploadImage", ".preview-img", "#fileLabelText");
+
+  const uploadForm = document.getElementById("uploadForm");
+  const uploadTagInput = document.getElementById("upload-tags");
+  const uploadTagify = initTagify(uploadTagInput);
+  initImagePreview("#noteFile", ".preview-note", "#noteFileLabel");
+
+  if (uploadForm) {
+    uploadForm.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      if (!uploadForm.checkValidity()) {
+        uploadForm.classList.add("was-validated");
+        return;
+      }
+      const formData = new FormData(uploadForm);
+      try {
+        const resp = await fetch(uploadForm.action, {
+          method: "POST",
+          body: formData,
+          headers: { "X-Requested-With": "XMLHttpRequest" },
+        });
+        if (!resp.ok) throw new Error("error");
+        uploadForm.reset();
+        if (uploadTagify) uploadTagify.removeAllTags();
+        showToast("✅ Apunte subido con éxito");
+      } catch (err) {
+        showToast("❌ Error al subir el apunte");
+      }
+    });
+  }
 
   const postForm = document.getElementById("postForm");
   if (postForm) {
@@ -472,4 +507,5 @@ document.addEventListener("DOMContentLoaded", () => {
   initFloatingSidebar();
   initActionButtons();
   initFeedForms();
+  initTooltips();
 });

--- a/crunevo/templates/feed.html
+++ b/crunevo/templates/feed.html
@@ -151,8 +151,8 @@
           <input type="file" name="file" accept="application/pdf" class="form-control mb-2" required>
           <input id="note-tags" name="tags" class="form-control mb-2" placeholder="Etiquetas">
           <div class="form-check mb-2">
-            <input class="form-check-input" type="checkbox" value="1" id="termsCheck" name="terms" required title="Confirmo que tengo permiso para compartir este material.\nNo infringe derechos de autor.\nEste material es educativo o de dominio público.">
-            <label class="form-check-label" for="termsCheck">✅ Acepto los Términos y Condiciones</label>
+            <input class="form-check-input" type="checkbox" value="1" id="termsCheck" name="terms" required>
+            <label class="form-check-label" for="termsCheck" data-bs-toggle="tooltip" data-bs-placement="top" title="Confirmo que tengo permiso para compartir este material. Puede tratarse de contenido público">✅ Acepto los Términos y Condiciones</label>
           </div>
         </div>
         <div class="modal-footer">

--- a/crunevo/templates/upload_note.html
+++ b/crunevo/templates/upload_note.html
@@ -20,8 +20,8 @@
     <div class="preview-note mb-2"></div>
     <input id="upload-tags" name="tags" class="form-control mb-2" placeholder="Etiquetas" value="{{ form_data.tags if form_data else '' }}">
     <div class="form-check mb-3">
-      <input class="form-check-input" type="checkbox" value="1" id="termsCheck" name="terms" required title="Confirmo que tengo permiso para compartir este material. Este contenido es público o tengo derechos para divulgarlo." {% if form_data and form_data.get('terms') %}checked{% endif %}>
-      <label class="form-check-label" for="termsCheck">✅ Acepto los Términos y Condiciones</label>
+      <input class="form-check-input" type="checkbox" value="1" id="termsCheck" name="terms" required {% if form_data and form_data.get('terms') %}checked{% endif %}>
+      <label class="form-check-label" for="termsCheck" data-bs-toggle="tooltip" data-bs-placement="top" title="Confirmo que tengo permiso para compartir este material. Puede tratarse de contenido público">✅ Acepto los Términos y Condiciones</label>
     </div>
     <button type="submit" class="btn btn-primary w-100">📤 Publicar Apunte</button>
   </form>
@@ -30,29 +30,5 @@
 
 {% block scripts %}
 <script src="https://cdn.jsdelivr.net/npm/@yaireo/tagify"></script>
-<script>
-const uploadForm = document.getElementById('uploadForm');
-const tagify = initTagify('#upload-tags');
-initImagePreview('#noteFile', '.preview-note', '#noteFileLabel');
-if (uploadForm) {
-  uploadForm.addEventListener('submit', async (e) => {
-    e.preventDefault();
-    if (!uploadForm.checkValidity()) {
-      uploadForm.classList.add('was-validated');
-      return;
-    }
-    const formData = new FormData(uploadForm);
-    try {
-      const resp = await fetch(uploadForm.action, { method: 'POST', body: formData, headers: { 'X-Requested-With': 'XMLHttpRequest' } });
-      if (!resp.ok) throw new Error('error');
-      uploadForm.reset();
-      if (tagify) tagify.removeAllTags();
-      showToast('✅ Apunte subido con éxito');
-    } catch (err) {
-      showToast('❌ Error al subir el apunte');
-    }
-  });
-}
-</script>
 {% endblock %}
 


### PR DESCRIPTION
## Resumen de cambios
- tooltips en checkbox de terminos en `feed.html` y `upload_note.html`
- se unificó manejo del formulario de subida en `main.js`
- se añadió función `initTooltips` e inicialización global
- actualizado `AGENTS.md` con registro de mejoras

## Pruebas realizadas
- `pip install -r requirements.txt`
- `pytest -q` *(falló: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68466a5f3024832598cacec4d2973b96