### PR TITLE
[Feat] Add social post comments and redesign feed

### DIFF
--- a/crunevo/__init__.py
+++ b/crunevo/__init__.py
@@ -15,6 +15,7 @@ from crunevo.models.note import (
     Report as _Report,
 )
 from crunevo.models.post import Post as _Post
+from crunevo.models.post_comment import PostComment as _PostComment
 from crunevo.models.product import Product as _Product
 from crunevo.models.forum import Pregunta as _Pregunta, Respuesta as _Respuesta
 from crunevo.models.log import LoginLog as _LoginLog
@@ -30,6 +31,7 @@ Product = _Product
 Pregunta = _Pregunta
 Respuesta = _Respuesta
 Post = _Post
+PostComment = _PostComment
 LoginLog = _LoginLog
 Comment = _Comment
 from crunevo.routes.main_routes import main_bp

--- a/crunevo/models/post_comment.py
+++ b/crunevo/models/post_comment.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+from crunevo.models import db
+
+
+class PostComment(db.Model):
+    __tablename__ = "post_comments"
+
+    id = db.Column(db.Integer, primary_key=True)
+    content = db.Column(db.Text, nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    post_id = db.Column(db.Integer, db.ForeignKey("posts.id"), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey("users.id"), nullable=False)
+
+    user = db.relationship("User", backref="post_comments")
+    post = db.relationship("Post", backref="comments")
+
+    def __repr__(self):
+        return f"<PostComment {self.id}>"

--- a/crunevo/static/css/custom_feed.css
+++ b/crunevo/static/css/custom_feed.css
@@ -283,8 +283,37 @@
   opacity: 0.5;
 }
 
-.post-card .note-actions {
-  display: none;
+
+.post-card .avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.section-title {
+  font-weight: 700;
+  font-size: 1.2rem;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.comment-area {
+  padding-left: 0.5rem;
+  padding-right: 0.5rem;
+}
+.comment-input {
+  font-size: 0.9rem;
+  margin-top: 0.5rem;
+}
+.btn-gradient {
+  background: linear-gradient(45deg, #5b7cfa, #4e54c8);
+  border: none;
+  color: #fff;
+}
+.btn-gradient:hover {
+  opacity: 0.9;
 }
 
 .post-card .note-title {

--- a/crunevo/templates/feed.html
+++ b/crunevo/templates/feed.html
@@ -13,45 +13,56 @@
   <div class="sidebar-left d-none d-lg-block"></div>
 
   <div class="feed-container">
-    <div class="post-toggle card shadow-sm p-3 mb-3">
+    <h2 class="section-title">📢 Publicaciones recientes</h2>
+    <div class="create-post card p-3 mb-3">
       <button id="openNoteModalBtn" class="btn btn-primary w-100 mb-2">📄 Subir Apunte</button>
 
       <form id="postForm" enctype="multipart/form-data">
-        <textarea name="content" class="form-control mb-2" rows="3" placeholder="Comparte una idea, resumen o duda académica..."></textarea>
-
-        <label for="uploadImage" class="btn btn-outline-secondary w-100">
+        <div class="input-wrapper mb-2">
+          <textarea name="content" class="form-control" rows="3" placeholder="Comparte una idea, resumen o duda académica..."></textarea>
+        </div>
+        <label for="uploadImage" class="btn btn-outline-secondary w-100 mb-2">
           <span id="fileLabelText">📎 Seleccionar imagen</span>
         </label>
         <input type="file" id="uploadImage" name="image" accept="image/*" class="d-none">
-        <div class="preview-img mt-2"></div>
+        <div class="preview-img mb-2"></div>
 
-        <button type="submit" class="btn btn-primary mt-2 w-100">📤 Publicar</button>
+        <button type="submit" class="btn btn-primary btn-gradient w-100">📤 Publicar</button>
       </form>
     </div>
 
     {% for post in posts %}
-    <article class="note-card post-card card animate-fade">
+    <article class="post-card card animate-fade mb-3">
       <div class="card-body">
-        <p class="note-meta mb-1">
-          <i class="fas fa-user me-1"></i>{{ post.uploader.name }} — {{ post.uploader.career or 'Carrera' }}
-        </p>
-        <p class="note-desc">{{ post.content }}</p>
+        <div class="post-header d-flex align-items-center mb-2">
+          <img src="{{ post.uploader.profile_picture_url or url_for('static', filename='images/default_avatar.png') }}" class="avatar me-2" alt="avatar">
+          <div>
+            <strong>{{ post.uploader.name }}</strong><br>
+            <small class="text-muted">{{ post.uploader.career or 'Carrera' }} · <i class="far fa-clock"></i> {{ post.timestamp.strftime('%d %b %Y') }}</small>
+          </div>
+        </div>
+        <p class="post-content">{{ post.content }}</p>
         {% if post.image_url %}
         <div class="text-center mt-2">
-          <img src="{{ post.image_url }}" class="img-fluid mx-auto d-block rounded shadow-sm" style="max-height: 300px; object-fit: contain;" alt="imagen">
+          <img src="{{ post.image_url }}" class="img-fluid rounded" style="max-height: 300px; object-fit: contain;" alt="imagen">
         </div>
         {% endif %}
       </div>
-      <div class="d-flex justify-content-around border-top pt-2 post-actions">
-        <button class="btn btn-light btn-sm action-post-btn" data-action="like" data-id="{{ post.id }}"><i class="fas fa-heart me-1 text-danger"></i>Me gusta</button>
-        <button class="btn btn-light btn-sm action-post-btn" data-action="comment" data-id="{{ post.id }}"><i class="fas fa-comment-alt me-1 text-secondary"></i>Comentar</button>
-        <button class="btn btn-light btn-sm action-post-btn" data-action="save" data-id="{{ post.id }}"><i class="fas fa-bookmark me-1 text-primary"></i>Guardar</button>
-        <button class="btn btn-light btn-sm action-post-btn" data-action="share" data-id="{{ post.id }}"><i class="fas fa-share me-1 text-info"></i>Compartir</button>
+      <div class="note-actions post-actions card-footer bg-white">
+        <div class="action-row d-flex">
+          <button class="action-btn" data-action="like" data-id="{{ post.id }}" data-bs-toggle="tooltip" title="Me gusta"><i class="fas fa-heart me-1"></i>Me gusta</button>
+          <button class="action-btn comment-toggle" data-id="{{ post.id }}" data-bs-toggle="tooltip" title="Comentar"><i class="fas fa-comment me-1"></i>Comentar</button>
+          <button class="action-btn" data-action="save" data-id="{{ post.id }}" data-bs-toggle="tooltip" title="Guardar"><i class="fas fa-bookmark me-1"></i>Guardar</button>
+          <button class="action-btn" data-action="share" data-id="{{ post.id }}" data-bs-toggle="tooltip" title="Compartir"><i class="fas fa-share me-1"></i>Compartir</button>
+        </div>
+      </div>
+      <div class="comment-area mt-2" data-id="{{ post.id }}" style="display:none;">
+        <input type="text" class="form-control comment-input" placeholder="Escribe un comentario..." />
       </div>
     </article>
     {% endfor %}
 
-    <h2 class="fw-bold mb-3 mt-4">📘 Apuntes Destacados</h2>
+    <h2 class="section-title mt-4">📘 Apuntes destacados <a href="{{ url_for('note.notes_section') }}" class="btn btn-link view-all">Ver todos los apuntes</a></h2>
 
     {% for note in notes %}
     <article class="note-card card animate-fade">

--- a/crunevo/tests/test_post_comments.py
+++ b/crunevo/tests/test_post_comments.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from crunevo.app import create_app
+from crunevo.models import db
+from crunevo.models.user import User
+from crunevo.models.post import Post
+from crunevo.models.post_comment import PostComment
+
+
+@pytest.fixture
+def app(tmp_path):
+    os.environ["SQLALCHEMY_DATABASE_URI"] = f"sqlite:///{tmp_path}/test.db"
+    application = create_app()
+    application.config["TESTING"] = True
+    application.config["WTF_CSRF_ENABLED"] = False
+    with application.app_context():
+        db.create_all()
+    return application
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+@pytest.fixture
+def user(app):
+    with app.app_context():
+        u = User(username="cposter", email="cposter@example.com")
+        u.set_password("secret")
+        db.session.add(u)
+        db.session.commit()
+        return u
+
+
+def login(client, email, password):
+    return client.post(
+        "/login", data={"email": email, "password": password}, follow_redirects=True
+    )
+
+
+def test_comment_post(client, user, app):
+    with app.app_context():
+        p = Post(content="hola", user_id=user.id)
+        db.session.add(p)
+        db.session.commit()
+        post_id = p.id
+    login(client, "cposter@example.com", "secret")
+    resp = client.post(f"/posts/{post_id}/comment", data={"content": "ok"})
+    assert resp.status_code == 302
+    with app.app_context():
+        assert PostComment.query.filter_by(post_id=post_id).count() == 1

--- a/migrations/versions/7c5da695d26a_add_post_comment_model.py
+++ b/migrations/versions/7c5da695d26a_add_post_comment_model.py
@@ -1,0 +1,32 @@
+"""add post comment model
+
+Revision ID: 7c5da695d26a
+Revises: 810dc2c6c5d4
+Create Date: 2025-06-10 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "7c5da695d26a"
+down_revision = "810dc2c6c5d4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "post_comments",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("timestamp", sa.DateTime(), nullable=True),
+        sa.Column("post_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.ForeignKeyConstraint(["post_id"], ["posts.id"]),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade():
+    op.drop_table("post_comments")


### PR DESCRIPTION
## Summary
- allow commenting on social posts with PostComment model
- tweak feed layout and action buttons
- add section titles and new styling
- implement comment form toggles via JS
- create migration for new PostComment table

## Testing
- `black . --quiet`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6846f4bbe0448325968fbe7af945e67d