### PR TITLE
[Feat] Modern mobile menu and unified comments

### DIFF
--- a/crunevo/static/css/custom_feed.css
+++ b/crunevo/static/css/custom_feed.css
@@ -23,6 +23,22 @@
     flex-direction: column;
 }
 
+.feed-container input.form-control,
+.feed-container textarea.form-control {
+    padding: 0.75rem 1rem;
+    border-radius: 0.5rem;
+    box-shadow: inset 0 0 0 1px #ccc;
+}
+.feed-container textarea.form-control {
+    min-height: 80px;
+    transition: box-shadow 0.2s, transform 0.2s;
+    resize: vertical;
+}
+.feed-container textarea.form-control:focus {
+    box-shadow: 0 0 0 2px rgba(91, 124, 250, 0.5);
+    transform: translateY(-2px);
+}
+
 .note-card {
     border-radius: 0;
     box-shadow: var(--card-shadow);
@@ -256,6 +272,10 @@
   .note-card + .note-card {
     border-top-color: #3a3b3c;
   }
+  .comment-list {
+    background: #2c2c2c;
+    border-top-color: #3a3b3c;
+  }
 }
 
 .input-wrapper input.form-control {
@@ -306,6 +326,16 @@
 .comment-input {
   font-size: 0.9rem;
   margin-top: 0.5rem;
+}
+.comment-list {
+  background: #f8f9fa;
+  border-top: 1px solid #e0e0e0;
+}
+.comment-list .avatar {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  object-fit: cover;
 }
 .btn-gradient {
   background: linear-gradient(45deg, #5b7cfa, #4e54c8);

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -49,12 +49,33 @@ body {
 }
 
 /* Estilos para el menú offcanvas en móviles */
+.offcanvas {
+    height: 100vh;
+    backdrop-filter: blur(4px);
+    background-color: rgba(255, 255, 255, 0.85);
+}
+.offcanvas-body {
+    overflow-y: auto;
+}
+.offcanvas-header .btn-close {
+    transition: transform 0.3s ease;
+}
+.offcanvas-header .btn-close:hover {
+    transform: rotate(90deg);
+}
 .offcanvas .nav-link {
     font-size: 1.2rem;
     padding: 0.75rem 1rem;
 }
 .offcanvas .nav-link i {
     width: 1.5rem;
+}
+
+@media (prefers-color-scheme: dark) {
+    .offcanvas {
+        background-color: rgba(33, 37, 41, 0.85);
+        color: #f8f9fa;
+    }
 }
 
 #floatingSidebar {

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -526,11 +526,21 @@ function initCommentInputs(scope = document) {
         if (!text) return;
         const formData = new FormData();
         formData.append('content', text);
-        const resp = await fetch(`/posts/${btn.dataset.id}/comment`, {
-          method: 'POST',
-          body: formData,
-          headers: { 'X-Requested-With': 'XMLHttpRequest' },
-        });
+        let resp;
+        if (btn.dataset.type === 'note') {
+          formData.append('note_id', btn.dataset.id);
+          resp = await fetch('/comments/add', {
+            method: 'POST',
+            body: formData,
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+          });
+        } else {
+          resp = await fetch(`/posts/${btn.dataset.id}/comment`, {
+            method: 'POST',
+            body: formData,
+            headers: { 'X-Requested-With': 'XMLHttpRequest' },
+          });
+        }
         if (resp.ok) {
           input.value = '';
           area.style.display = 'none';

--- a/crunevo/templates/feed.html
+++ b/crunevo/templates/feed.html
@@ -32,7 +32,7 @@
     </div>
 
     {% for post in posts %}
-    <article class="post-card card animate-fade mb-3">
+    <article class="post-card card shadow-sm rounded border-0 animate-fade mb-3">
       <div class="card-body">
         <div class="post-header d-flex align-items-center mb-2">
           <img src="{{ post.uploader.profile_picture_url or url_for('static', filename='images/default_avatar.png') }}" class="avatar me-2" alt="avatar">
@@ -51,12 +51,26 @@
       <div class="note-actions post-actions card-footer bg-white">
         <div class="action-row d-flex">
           <button class="action-btn" data-action="like" data-id="{{ post.id }}" data-bs-toggle="tooltip" title="Me gusta"><i class="fas fa-heart me-1"></i>Me gusta</button>
-          <button class="action-btn comment-toggle" data-id="{{ post.id }}" data-bs-toggle="tooltip" title="Comentar"><i class="fas fa-comment me-1"></i>Comentar</button>
+          <button class="action-btn comment-toggle" data-id="{{ post.id }}" data-type="post" data-bs-toggle="tooltip" title="Comentar"><i class="fas fa-comment me-1"></i>Comentar</button>
           <button class="action-btn" data-action="save" data-id="{{ post.id }}" data-bs-toggle="tooltip" title="Guardar"><i class="fas fa-bookmark me-1"></i>Guardar</button>
           <button class="action-btn" data-action="share" data-id="{{ post.id }}" data-bs-toggle="tooltip" title="Compartir"><i class="fas fa-share me-1"></i>Compartir</button>
         </div>
       </div>
-      <div class="comment-area mt-2" data-id="{{ post.id }}" style="display:none;">
+      {% if post.comments %}
+      <div class="comment-list px-3 py-2">
+        {% for c in post.comments[:2] %}
+        <div class="d-flex mb-2">
+          <img src="{{ c.user.profile_picture_url or url_for('static', filename='images/default_avatar.png') }}" class="avatar me-2" alt="avatar">
+          <div>
+            <strong>{{ c.user.name }}</strong>
+            <p class="mb-0 text-muted" style="font-size:0.8rem;">{{ c.timestamp.strftime('%d %b %Y') }}</p>
+            <p class="mb-0">{{ c.content }}</p>
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+      {% endif %}
+      <div class="comment-area mt-2 px-3" data-id="{{ post.id }}" data-type="post" style="display:none;">
         <input type="text" class="form-control comment-input" placeholder="Escribe un comentario..." />
       </div>
     </article>
@@ -65,7 +79,7 @@
     <h2 class="section-title mt-4">📘 Apuntes destacados <a href="{{ url_for('note.notes_section') }}" class="btn btn-link view-all">Ver todos los apuntes</a></h2>
 
     {% for note in notes %}
-    <article class="note-card card animate-fade">
+    <article class="note-card card shadow-sm rounded border-0 animate-fade">
         <div class="note-image">
             {% if note.file_type == 'pdf' %}
                 <embed
@@ -96,6 +110,7 @@
                 <i class="fas fa-user me-1"></i>{{ note.uploader.name }} –
                 {{ note.uploader.career or 'Carrera' }}
             </p>
+            <p class="note-meta mb-1 text-muted"><i class="far fa-clock me-1"></i>{{ note.upload_date.strftime('%d %b %Y') }}</p>
             <p class="note-meta mb-1">{{ note.page_count or '?' }} páginas</p>
             {% if note.faculty %}
             <span class="badge text-white mb-1" data-facultad="{{ note.faculty }}">{{ note.faculty }}</span>
@@ -112,7 +127,7 @@
                 <button class="action-btn" data-action="like" data-id="{{ note.id }}" aria-label="Me gusta">
                     <i class="fas fa-heart me-1"></i>Me gusta
                 </button>
-                <button class="action-btn" data-action="comment" data-id="{{ note.id }}" aria-label="Comentar">
+                <button class="action-btn comment-toggle" data-action="comment" data-type="note" data-id="{{ note.id }}" aria-label="Comentar">
                     <i class="fas fa-comment me-1"></i>Comentar
                 </button>
                 <button class="action-btn" data-action="save" data-id="{{ note.id }}" aria-label="Guardar">
@@ -131,6 +146,23 @@
                     <i class="fas fa-share me-1"></i>Compartir
                 </button>
             </div>
+        </div>
+        {% if note.comments %}
+        <div class="comment-list px-3 py-2">
+            {% for c in note.comments[:2] %}
+            <div class="d-flex mb-2">
+                <img src="{{ c.user.profile_picture_url or url_for('static', filename='images/default_avatar.png') }}" class="avatar me-2" alt="avatar">
+                <div>
+                    <strong>{{ c.user.name }}</strong>
+                    <p class="mb-0 text-muted" style="font-size:0.8rem;">{{ c.timestamp.strftime('%d %b %Y') }}</p>
+                    <p class="mb-0">{{ c.content }}</p>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+        {% endif %}
+        <div class="comment-area mt-2 px-3" data-id="{{ note.id }}" data-type="note" style="display:none;">
+            <input type="text" class="form-control comment-input" placeholder="Escribe un comentario..." />
         </div>
     </article>
 

--- a/crunevo/templates/navbar.html
+++ b/crunevo/templates/navbar.html
@@ -6,7 +6,7 @@
         </button>
 
 
-        <div class="offcanvas offcanvas-start" tabindex="-1" id="mobileMenu" aria-labelledby="mobileMenuLabel">
+        <div class="offcanvas offcanvas-start" tabindex="-1" id="mobileMenu" aria-labelledby="mobileMenuLabel" data-bs-scroll="true">
             <div class="offcanvas-header">
                 <h5 class="offcanvas-title" id="mobileMenuLabel">CRUNEVO</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"></button>

--- a/crunevo/tests/test_post_comments.py
+++ b/crunevo/tests/test_post_comments.py
@@ -30,7 +30,7 @@ def user(app):
         u.set_password("secret")
         db.session.add(u)
         db.session.commit()
-        return u
+        return u.id
 
 
 def login(client, email, password):
@@ -41,7 +41,7 @@ def login(client, email, password):
 
 def test_comment_post(client, user, app):
     with app.app_context():
-        p = Post(content="hola", user_id=user.id)
+        p = Post(content="hola", user_id=user)
         db.session.add(p)
         db.session.commit()
         post_id = p.id


### PR DESCRIPTION
## Summary
- redesign offcanvas menu with blur backdrop and dark mode
- show comments in unified feed for posts and notes
- stylize feed forms and comment inputs
- support posting comments to notes via AJAX
- fix detached user fixture in post comment tests

## Testing
- `black .`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846fba04c008325abbef3f096ccdc07