### PR TITLE
[Enhancement] Refinar navbar y tarjetas del feed

### DIFF
--- a/crunevo/static/css/custom_feed.css
+++ b/crunevo/static/css/custom_feed.css
@@ -3,6 +3,24 @@
     --card-shadow: 0 4px 8px rgba(0,0,0,0.1);
 }
 
+/* Offcanvas menu ajustes */
+.offcanvas {
+  height: 100vh;
+  overflow-y: auto;
+  backdrop-filter: blur(4px);
+}
+.offcanvas.show .btn-close {
+  transition: transform 0.3s;
+  transform: rotate(90deg);
+}
+
+@media (prefers-color-scheme: dark) {
+  .offcanvas {
+    backdrop-filter: blur(6px);
+    background-color: rgba(30, 30, 30, 0.9);
+  }
+}
+
 .feed-container .btn-primary {
     background-color: #1877f2;
     border-color: #1877f2;
@@ -16,11 +34,12 @@
 
 .feed-container {
     width: 100%;
-    max-width: none;
-    margin: 0;
-    padding: 0;
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 1rem;
     display: flex;
     flex-direction: column;
+    gap: 1.5rem;
 }
 
 .feed-container input.form-control,
@@ -40,7 +59,17 @@
 }
 
 .note-card {
-    border-radius: 0;
+    border-radius: 0.75rem;
+    box-shadow: var(--card-shadow);
+    overflow: hidden;
+    background: #fff;
+    border: none;
+    color: #050505;
+    transition: transform 0.2s ease-in-out;
+}
+
+.post-card {
+    border-radius: 0.75rem;
     box-shadow: var(--card-shadow);
     overflow: hidden;
     background: #fff;
@@ -71,7 +100,9 @@
 .note-image img,
 .note-image embed {
     width: 100%;
+    max-height: 200px;
     height: auto;
+    object-fit: cover;
     border-radius: var(--card-radius) var(--card-radius) 0 0;
     border: none;
 }
@@ -161,6 +192,7 @@
         padding: 0;
         margin: 0;
         max-width: none;
+        gap: 1rem;
     }
     .note-card {
         width: 100%;
@@ -322,6 +354,9 @@
 .comment-area {
   padding-left: 0.5rem;
   padding-right: 0.5rem;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease;
 }
 .comment-input {
   font-size: 0.9rem;

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -22,6 +22,12 @@ body {
 .navbar {
     border-radius: 0.5rem;
     box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+    padding: 0.5rem 1rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    color: #333;
 }
 
 .nav-link:hover,
@@ -46,6 +52,29 @@ body {
 .btn:focus {
     opacity: 0.9;
     box-shadow: 0 0 5px rgba(0,0,0,0.1);
+}
+
+.user-summary strong {
+    font-size: 0.9rem;
+}
+
+.user-summary small {
+    font-size: 0.75rem;
+}
+
+/* Avatares genéricos */
+.avatar {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+.avatar-sm {
+    width: 30px;
+    height: 30px;
+    border-radius: 50%;
+    object-fit: cover;
 }
 
 /* Estilos renovados para el menú offcanvas */
@@ -94,6 +123,15 @@ body {
 @media (prefers-color-scheme: dark) {
     .offcanvas {
         background: #1f1f1f;
+        color: #f1f1f1;
+    }
+
+    .navbar {
+        background-color: #222;
+        color: #f1f1f1;
+    }
+
+    .navbar a {
         color: #f1f1f1;
     }
 

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -510,14 +510,22 @@ function addNoteToFeed(note) {
   initCommentInputs();
 }
 
+function slideToggle(el) {
+  if (el.style.maxHeight && el.style.maxHeight !== '0px') {
+    el.style.maxHeight = '0';
+  } else {
+    el.style.maxHeight = el.scrollHeight + 'px';
+  }
+}
+
 function initCommentInputs(scope = document) {
   scope.querySelectorAll('.comment-toggle').forEach((btn) => {
     const area = scope.querySelector(`.comment-area[data-id="${btn.dataset.id}"]`);
     if (!area) return;
     const input = area.querySelector('.comment-input');
     btn.addEventListener('click', () => {
-      area.style.display = area.style.display === 'none' ? 'block' : 'none';
-      if (area.style.display !== 'none') input.focus();
+      slideToggle(area);
+      if (area.style.maxHeight !== '0px') input.focus();
     });
     input.addEventListener('keydown', async (e) => {
       if (e.key === 'Enter' && !e.shiftKey) {
@@ -543,7 +551,7 @@ function initCommentInputs(scope = document) {
         }
         if (resp.ok) {
           input.value = '';
-          area.style.display = 'none';
+          area.style.maxHeight = '0';
           showToast('✅ Comentario publicado');
         } else {
           showToast('❌ Error al comentar');

--- a/crunevo/templates/feed.html
+++ b/crunevo/templates/feed.html
@@ -32,10 +32,10 @@
     </div>
 
     {% for item in items %}
-    <article class="note-card post-card card shadow-sm rounded border-0 animate-fade mb-3">
+    <article class="card shadow-sm rounded border-0 animate-fade mb-3 {{ 'post-card' if item.__tablename__ == 'posts' else 'note-card' }}">
       <div class="card-body">
-        <div class="post-header d-flex align-items-center mb-2">
-          <img src="{{ item.uploader.profile_picture_url or url_for('static', filename='images/default_avatar.png') }}" class="avatar me-2" alt="avatar">
+        <div class="post-header d-flex align-items-center gap-2 mb-2">
+          <img src="{{ item.uploader.profile_picture_url or url_for('static', filename='images/default_avatar.png') }}" class="avatar" alt="avatar">
           <div>
             <strong>{{ item.uploader.name }}</strong><br>
             <small class="text-muted">{{ item.uploader.career or 'Carrera' }} ·<i class="far fa-clock"></i> {{ item.created_at.strftime('%d %b %Y') }}</small>
@@ -84,8 +84,8 @@
       {% if item.comments %}
       <div class="comment-list px-3 py-2">
         {% for c in item.comments[:2] %}
-        <div class="d-flex mb-2">
-          <img src="{{ c.user.profile_picture_url or url_for('static', filename='images/default_avatar.png') }}" class="avatar me-2" alt="avatar">
+        <div class="d-flex gap-2 mb-2">
+          <img src="{{ c.user.profile_picture_url or url_for('static', filename='images/default_avatar.png') }}" class="avatar" alt="avatar">
           <div>
             <strong>{{ c.user.name }}</strong>
             <p class="mb-0 text-muted" style="font-size:0.8rem;">{{ c.timestamp.strftime('%d %b %Y') }}</p>
@@ -95,7 +95,7 @@
         {% endfor %}
       </div>
       {% endif %}
-      <div class="comment-area mt-2 px-3" data-id="{{ item.id }}" data-type="{{ 'post' if item.__tablename__ == 'posts' else 'note' }}" style="display:none;">
+      <div class="comment-area mt-2 px-3" data-id="{{ item.id }}" data-type="{{ 'post' if item.__tablename__ == 'posts' else 'note' }}">
         <input type="text" class="form-control comment-input" placeholder="Escribe un comentario..." />
       </div>
     </article>

--- a/crunevo/templates/navbar.html
+++ b/crunevo/templates/navbar.html
@@ -1,9 +1,20 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light shadow-sm fixed-top">
-    <div class="container-fluid">
+    <div class="container-fluid d-flex align-items-center justify-content-between">
         <a class="navbar-brand" href="{{ url_for('main.index') }}">CRUNEVO</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#mobileMenu" aria-controls="mobileMenu" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
+        <div class="d-flex align-items-center gap-2">
+            {% if current_user.is_authenticated %}
+            <div class="d-flex align-items-center user-summary gap-2 me-2">
+                <img src="{{ current_user.profile_picture_url or url_for('static', filename='images/default_avatar.png') }}" class="avatar" alt="avatar" data-bs-toggle="tooltip" title="{{ current_user.name }}">
+                <div class="d-none d-md-block text-end">
+                    <strong>{{ current_user.name }}</strong><br>
+                    <small class="text-muted">{{ current_user.email }}</small>
+                </div>
+            </div>
+            {% endif %}
+            <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#mobileMenu" aria-controls="mobileMenu" aria-label="Toggle navigation">
+                <span class="navbar-toggler-icon"></span>
+            </button>
+        </div>
 
 
         <div class="offcanvas offcanvas-start" tabindex="-1" id="mobileMenu" aria-labelledby="mobileMenuLabel">


### PR DESCRIPTION
## Resumen de cambios
- Navbar compacto con avatar y datos ocultables
- Feed centrado y tarjetas unificadas para notas y posts
- Imágenes limitadas a 200px y avatares de 40px
- Ajustes menores en animación de comentarios y estilo oscuro

## Pruebas realizadas
- `black .`
- `pip install -r requirements.txt`
- `pytest -q` *(falló: ModuleNotFoundError para `crunevo`)*

------
https://chatgpt.com/codex/tasks/task_e_68476b4952708325b803b2d5ea788864