### PR TITLE
[Fix] replace deprecated query.get

### DIFF
--- a/crunevo/__init__.py
+++ b/crunevo/__init__.py
@@ -89,7 +89,7 @@ def create_app():
 
     @login_manager.user_loader
     def load_user(user_id: str):
-        return User.query.get(int(user_id))
+        return db.session.get(User, int(user_id))
 
     app.register_blueprint(main_bp)
     app.register_blueprint(auth_bp)

--- a/crunevo/routes/comments_routes.py
+++ b/crunevo/routes/comments_routes.py
@@ -53,7 +53,7 @@ def like_comment(id: int):
 
     comment.likes = (comment.likes or 0) + 1
     if comment.likes == 5:
-        user = User.query.get(comment.user_id)
+        user = db.session.get(User, comment.user_id)
         if user:
             user.credits = (user.credits or 0) + 2
     db.session.commit()

--- a/crunevo/routes/note_routes.py
+++ b/crunevo/routes/note_routes.py
@@ -150,7 +150,7 @@ def upload_note():
                         upload_date=datetime.utcnow(),
                     )
 
-                    user = User.query.get(user_id)
+                    user = db.session.get(User, user_id)
                     if user:
                         user.credits = (user.credits or 0) + 10
 


### PR DESCRIPTION
## Summary
- replace deprecated `query.get` calls with `db.session.get`

## Testing
- `pip install -q -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684772cd4ff08325a805e5eee12520d3