### PR TITLE
[Enhancement] Improve feed visuals and mobile menu

### DIFF
--- a/crunevo/static/css/custom_feed.css
+++ b/crunevo/static/css/custom_feed.css
@@ -83,18 +83,13 @@
 }
 
 .animate-fade {
-    animation: fadeInUp 0.5s ease-out;
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.6s ease, transform 0.6s ease;
 }
-
-@keyframes fadeInUp {
-    0% {
-        opacity: 0;
-        transform: translateY(20px);
-    }
-    100% {
-        opacity: 1;
-        transform: translateY(0);
-    }
+.animate-fade.visible {
+    opacity: 1;
+    transform: translateY(0);
 }
 
 .note-image img,
@@ -122,6 +117,16 @@
     font-size: 1rem;
     color: #444;
     margin-bottom: 1rem;
+}
+.note-desc.collapsed {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+}
+.show-more-btn {
+    font-size: 0.9rem;
+    color: #1877f2;
 }
 
 .note-meta {
@@ -377,8 +382,21 @@
   border: none;
   color: #fff;
 }
-.btn-gradient:hover {
+.btn-gradient:hover,
+.btn-gradient:focus,
+#openNoteModalBtn:hover,
+#openNoteModalBtn:focus,
+.action-btn[data-action="download"]:hover,
+.action-btn[data-action="download"]:focus {
+  transform: scale(1.02);
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.15);
   opacity: 0.9;
+}
+
+.btn-gradient:active,
+#openNoteModalBtn:active,
+.action-btn[data-action="download"]:active {
+  transform: scale(0.98);
 }
 
 .post-card .note-title {

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -91,7 +91,7 @@ body {
 
 .offcanvas .nav-link {
     font-size: 1.1rem;
-    padding: 0.75rem 1.25rem;
+    padding: 1rem 1.25rem;
     border-bottom: 1px solid #f0f0f0;
     color: #333;
     display: flex;
@@ -103,8 +103,9 @@ body {
     background-color: #f8f9fa;
 }
 .offcanvas .nav-link i {
-    width: 20px;
+    width: 24px;
     text-align: center;
+    font-size: 1.25rem;
 }
 
 .offcanvas .user-info {

--- a/crunevo/static/js/main.js
+++ b/crunevo/static/js/main.js
@@ -362,14 +362,16 @@ function initImagePreview(fileSelector, previewSelector, labelSelector) {
 
 function initFeedForms() {
   const openNoteBtn = document.getElementById("openNoteModalBtn");
+  const floatUploadBtn = document.getElementById("floatUploadBtn");
   const noteModalEl = document.getElementById("uploadNoteModal");
   const noteForm = document.getElementById("noteForm");
   const tagInput = document.getElementById("note-tags");
 
   let noteModal;
-  if (openNoteBtn && noteModalEl) {
+  if ((openNoteBtn || floatUploadBtn) && noteModalEl) {
     noteModal = new bootstrap.Modal(noteModalEl);
-    openNoteBtn.addEventListener("click", () => noteModal.show());
+    if (openNoteBtn) openNoteBtn.addEventListener("click", () => noteModal.show());
+    if (floatUploadBtn) floatUploadBtn.addEventListener("click", () => noteModal.show());
   }
 
   const tagify = initTagify(tagInput);
@@ -487,6 +489,7 @@ function initFeedForms() {
     container.insertBefore(article, container.querySelector(".create-post").nextSibling);
     initActionButtons();
     initCommentInputs(article);
+    observeFadeIn(article);
   }
 
 function addNoteToFeed(note) {
@@ -504,6 +507,8 @@ function addNoteToFeed(note) {
       </div>`;
   const target = container.querySelector(".create-post").nextSibling;
   container.insertBefore(article, target);
+  observeFadeIn(article);
+  initDescriptionToggle(article);
   }
 
 
@@ -516,6 +521,30 @@ function slideToggle(el) {
   } else {
     el.style.maxHeight = el.scrollHeight + 'px';
   }
+}
+
+function observeFadeIn(element) {
+  if (!window.intersectionObserver) {
+    window.intersectionObserver = new IntersectionObserver((entries, obs) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible');
+          obs.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.1 });
+  }
+  window.intersectionObserver.observe(element);
+}
+
+function initDescriptionToggle(scope = document) {
+  scope.querySelectorAll('.show-more-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const desc = btn.previousElementSibling;
+      desc.classList.toggle('collapsed');
+      btn.textContent = desc.classList.contains('collapsed') ? 'Mostrar más' : 'Mostrar menos';
+    });
+  });
 }
 
 function initCommentInputs(scope = document) {
@@ -568,5 +597,7 @@ document.addEventListener("DOMContentLoaded", () => {
   initActionButtons();
   initFeedForms();
   initCommentInputs();
+  initDescriptionToggle();
+  document.querySelectorAll('.animate-fade').forEach(observeFadeIn);
   initTooltips();
 });

--- a/crunevo/templates/feed.html
+++ b/crunevo/templates/feed.html
@@ -14,7 +14,7 @@
 
   <div class="feed-container">
     <h2 class="section-title">📰 Últimas novedades</h2>
-    <div class="create-post card p-3 mb-3">
+    <div class="create-post card p-3 mb-3 position-relative">
       <button id="openNoteModalBtn" class="btn btn-primary w-100 mb-2">📄 Subir Apunte</button>
 
       <form id="postForm" enctype="multipart/form-data">
@@ -30,10 +30,16 @@
         <button type="submit" class="btn btn-primary btn-gradient w-100">📤 Publicar</button>
       </form>
     </div>
+    <button class="btn btn-primary position-fixed bottom-0 end-0 m-3 rounded-circle shadow d-md-none" id="floatUploadBtn">
+      <i class="fas fa-upload"></i>
+    </button>
 
     {% for item in items %}
     <article class="card shadow-sm rounded border-0 animate-fade mb-3 {{ 'post-card' if item.__tablename__ == 'posts' else 'note-card' }}">
       <div class="card-body">
+        {% if (item.created_at.date() == now().date()) %}
+        <span class="badge bg-success float-end">🆕 Nuevo</span>
+        {% endif %}
         <div class="post-header d-flex align-items-center gap-2 mb-2">
           <img src="{{ item.uploader.profile_picture_url or url_for('static', filename='images/default_avatar.png') }}" class="avatar" alt="avatar">
           <div>
@@ -65,7 +71,10 @@
           <p class="note-meta mb-1">{{ item.page_count or '?' }} páginas</p>
           {% if item.faculty %}<span class="badge text-white mb-1" data-facultad="{{ item.faculty }}">{{ item.faculty }}</span>{% endif %}
           {% if item.course %}<span class="badge bg-secondary mb-1"><i class="fas fa-book-open me-1"></i>{{ item.course }}</span>{% endif %}
-          <p class="note-desc">{{ item.description[:120] }}...</p>
+          <p class="note-desc{% if item.description and item.description|length > 300 %} collapsed{% endif %}">{{ item.description }}</p>
+          {% if item.description and item.description|length > 300 %}
+          <button class="btn btn-link show-more-btn p-0">Mostrar más</button>
+          {% endif %}
         {% endif %}
       </div>
       <div class="note-actions post-actions card-footer bg-white">
@@ -106,6 +115,11 @@
     </div>
     {% endif %}
     {% endfor %}
+
+    <div class="note-card p-3 text-center bg-light">
+      🤖 <strong>Sugerencia:</strong> Explora apuntes populares de tu facultad
+      <a href="{{ url_for('note.notes_section') }}" class="btn btn-sm btn-outline-primary mt-2">Ver ahora</a>
+    </div>
 
   </div>
   <div class="sidebar-right d-none d-lg-block"></div>


### PR DESCRIPTION
## Summary
- add mobile floating button for uploading notes
- mark new posts with badge
- clamp long descriptions and add 'Mostrar más' toggle
- add suggestion card at bottom of feed
- add fade-in animations via IntersectionObserver
- improve button hover effects
- enlarge mobile menu icons and padding

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError for flask)*

------
https://chatgpt.com/codex/tasks/task_e_684776163d588325acf39d55d992ac14