### PR TITLE
[Fix] Ajustar sidebar en landing page

### DIFF
--- a/crunevo/static/css/home.css
+++ b/crunevo/static/css/home.css
@@ -40,3 +40,9 @@
 .cta {
     background-color: #f8f9fa;
 }
+
+/* Oculta sidebars del feed en la landing */
+.sidebar-left,
+.sidebar-right {
+    display: none !important;
+}

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -166,6 +166,7 @@ body {
     font-size: 1.5rem;
     text-decoration: none;
     transition: transform 0.2s;
+    color: #000;
 }
 
 #floatingSidebarContent a:hover {

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -9,7 +9,9 @@
     {% block head_extra %}{% endblock %}
 </head>
 <body>
-    {% include 'components/sidebar_icons.html' %}
+    {% if request.endpoint != 'main.index' %}
+        {% include 'components/sidebar_icons.html' %}
+    {% endif %}
     {% include 'navbar.html' %}
 
     {% with messages = get_flashed_messages(with_categories=true) %}


### PR DESCRIPTION
## Summary
- hide floating sidebar on homepage
- ensure floating sidebar links are visible
- hide feed sidebars in landing styles

## Testing
- `black .`
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847b15f14748325aa032576119c538d