### PR TITLE
[Fix] Ajustar sidebar en landing page

### DIFF
--- a/crunevo/static/css/home.css
+++ b/crunevo/static/css/home.css
@@ -40,3 +40,16 @@
 .cta {
     background-color: #f8f9fa;
 }
+
+/* Oculta sidebars del feed en la landing */
+.sidebar-left,
+.sidebar-right {
+    display: none !important;
+}
+
+/* Ajusta el contenedor principal en la landing */
+.feed-container {
+    max-width: 100% !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+}

--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -166,6 +166,7 @@ body {
     font-size: 1.5rem;
     text-decoration: none;
     transition: transform 0.2s;
+    color: #000;
 }
 
 #floatingSidebarContent a:hover {

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -9,7 +9,9 @@
     {% block head_extra %}{% endblock %}
 </head>
 <body>
-    {% include 'components/sidebar_icons.html' %}
+    {% if request.endpoint != 'main.index' %}
+        {% include 'components/sidebar_icons.html' %}
+    {% endif %}
     {% include 'navbar.html' %}
 
     {% with messages = get_flashed_messages(with_categories=true) %}
@@ -23,8 +25,16 @@
       {% endif %}
     {% endwith %}
 
-    <div class="container-fluid p-0 main-container">
-        {% block content %}{% endblock %}
+    <div class="container-fluid p-0 main-container d-flex">
+        {% if request.endpoint != 'main.index' %}
+            <div class="sidebar-left d-none d-lg-block"></div>
+        {% endif %}
+        <div class="feed-container w-100">
+            {% block content %}{% endblock %}
+        </div>
+        {% if request.endpoint != 'main.index' %}
+            <div class="sidebar-right d-none d-lg-block"></div>
+        {% endif %}
     </div>
     {% include 'components/toast.html' %}
     <script src="{{ url_for('static', filename='js/bootstrap.bundle.min.js') }}"></script>

--- a/crunevo/templates/feed.html
+++ b/crunevo/templates/feed.html
@@ -9,12 +9,9 @@
 {% endblock %}
 
 {% block content %}
-<div class="main-container">
-  <div class="sidebar-left d-none d-lg-block"></div>
 
-  <div class="feed-container">
-    <h2 class="section-title">📰 Últimas novedades</h2>
-    <div class="create-post card p-3 mb-3 position-relative">
+  <h2 class="section-title">📰 Últimas novedades</h2>
+  <div class="create-post card p-3 mb-3 position-relative">
       <button id="openNoteModalBtn" class="btn btn-primary w-100 mb-2">📄 Subir Apunte</button>
 
       <form id="postForm" enctype="multipart/form-data">
@@ -121,9 +118,7 @@
       <a href="{{ url_for('note.notes_section') }}" class="btn btn-sm btn-outline-primary mt-2">Ver ahora</a>
     </div>
 
-  </div>
-  <div class="sidebar-right d-none d-lg-block"></div>
-</div>
+    </div>
 
 <!-- Modal de subida de apunte -->
 <div class="modal fade" id="uploadNoteModal" tabindex="-1" aria-hidden="true">


### PR DESCRIPTION
## Summary
- prevent sidebar markup from rendering on homepage
- remove redundant wrapper divs from feed page
- keep feed centered on landing with custom CSS

## Testing
- `black .`
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847b15f14748325aa032576119c538d