### PR TITLE
[Fix] Improve desktop sidebar contrast

### DIFF
--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -173,6 +173,18 @@ body {
     transform: scale(1.1);
 }
 
+@media (min-width: 768px) {
+    .sidebar-left {
+        background-color: #1f1f2e;
+        color: #ffffff;
+        min-height: 100vh;
+        padding: 1rem;
+    }
+    .sidebar-left a {
+        color: #ffffff;
+    }
+}
+
 .feed-container {
     flex-grow: 1;
     max-width: 100%;


### PR DESCRIPTION
## Summary
- adjust `.sidebar-left` styles for better visibility on large screens

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6847c8e7ad3083259adcb0c13ee0f3f6