### PR TITLE
[Fix] Clean up desktop navigation

### DIFF
--- a/crunevo/static/css/style.css
+++ b/crunevo/static/css/style.css
@@ -337,3 +337,10 @@ body {
   font-size: 1rem;
   border-bottom: 1px solid #e5e5e5;
 }
+
+@media (min-width: 992px) {
+  .sidebar-left,
+  .sidebar-right {
+    display: none !important;
+  }
+}

--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -9,7 +9,8 @@
     {% block head_extra %}{% endblock %}
 </head>
 <body>
-    {% if request.endpoint != 'main.index' %}
+    {% set is_desktop = request.user_agent.platform in ['linux', 'windows', 'macos'] %}
+    {% if not is_desktop and request.endpoint != 'main.index' %}
         {% include 'components/sidebar_icons.html' %}
     {% endif %}
     {% include 'navbar.html' %}


### PR DESCRIPTION
## Resumen de cambios
- no cargar `sidebar_icons.html` en equipos de escritorio
- ocultar `.sidebar-left` y `.sidebar-right` por CSS en pantallas grandes

## Pruebas realizadas
- `pip install -r requirements.txt`
- `black .`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6847d39635c883258de312c60c9d0215