### PR TITLE
[Fix] Conditional sidebar rendering

### DIFF
--- a/crunevo/templates/base.html
+++ b/crunevo/templates/base.html
@@ -27,14 +27,14 @@
     {% endwith %}
 
     {% set is_feed = current_user.is_authenticated and request.endpoint == 'main.index' %}
-    <div class="container-fluid p-0 main-container d-flex">
-        {% if is_feed %}
+    <div class="container-fluid p-0 {% if is_feed and not is_desktop %}main-container d-flex{% endif %}">
+        {% if is_feed and not is_desktop %}
             {% include 'components/sidebar_left.html' %}
         {% endif %}
         <div class="feed-container w-100 {% if not is_feed %}full-width{% endif %}">
             {% block content %}{% endblock %}
         </div>
-        {% if is_feed %}
+        {% if is_feed and not is_desktop %}
             {% include 'components/sidebar_right.html' %}
         {% endif %}
     </div>


### PR DESCRIPTION
## Summary
- avoid rendering sidebars on desktop

## Testing
- `black .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6847d59ff5d88325baef0b623ba84a63