### PR TITLE
fix: update gateway wildcard routes for NestJS 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ REALTIME_SERVICE_URL="http://localhost:3005"
 PORT=3000
 ```
 
-Las rutas comodín del gateway usan la sintaxis `*path` de NestJS 11 para enrutar todas las peticiones (por ejemplo, `/api/users/*path`).
+Las rutas comodín del gateway usan la sintaxis `*path` de NestJS 11 para enrutar todas las peticiones (por ejemplo, `/api/users/*path`), requerida por la actual versión de `path-to-regexp`.
 
 ### Frontend
 ```env

--- a/services/api-gateway/src/proxy/proxy.controller.ts
+++ b/services/api-gateway/src/proxy/proxy.controller.ts
@@ -72,7 +72,7 @@ export class ProxyController {
 
   // Users routes (protected)
   @UseGuards(JwtAuthGuard)
-  @All('users/:path*')
+  @All('users/*path')
   async forwardUsersRequest(
     @Req() req: Request,
     @Res() res: Response,
@@ -86,7 +86,7 @@ export class ProxyController {
 
   // Posts routes (protected)
   @UseGuards(JwtAuthGuard)
-  @All('posts/:path*')
+  @All('posts/*path')
   async forwardPostsRequest(
     @Req() req: Request,
     @Res() res: Response,
@@ -100,7 +100,7 @@ export class ProxyController {
 
   // Messages routes (protected)
   @UseGuards(JwtAuthGuard)
-  @All('messages/:path*')
+  @All('messages/*path')
   async forwardMessagesRequest(
     @Req() req: Request,
     @Res() res: Response,
@@ -114,7 +114,7 @@ export class ProxyController {
 
   // Search routes (protected)
   @UseGuards(JwtAuthGuard)
-  @All('search/:path*')
+  @All('search/*path')
   async forwardSearchRequest(
     @Req() req: Request,
     @Res() res: Response,


### PR DESCRIPTION
## Summary
- fix gateway wildcard routes to use new `*path` syntax
- document `path-to-regexp` requirement for wildcard routes

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68c0afec1f188321a96811284e6c2897