### PR TITLE
chore: generate prisma client before dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Una red social moderna construida con arquitectura de microservicios usando Reac
    npm run dev
    ```
 
+   > Nota: Los scripts `start:dev` de los microservicios ahora ejecutan `prisma generate` automáticamente para evitar errores de módulos faltantes al trabajar con Docker.
+
 ### Producción con Docker
 
 1. **Construir y ejecutar todos los servicios**

--- a/services/identity/package.json
+++ b/services/identity/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "npm run build && node dist/main.js",
-    "build": "tsc -p tsconfig.json",
+    "build": "npx prisma generate && tsc -p tsconfig.json",
+    "start:dev": "npx prisma generate && ts-node src/main.ts",
     "lint": "echo 'lint'",
     "test": "echo 'test'",
     "migrate": "echo 'migrate'",

--- a/services/messages/package.json
+++ b/services/messages/package.json
@@ -4,9 +4,9 @@
   "description": "CRUNEVO Messages Service - Real-time messaging and chat functionality",
   "main": "dist/main.js",
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "npx prisma generate && tsc -p tsconfig.json",
     "start": "node dist/main.js",
-    "start:dev": "ts-node src/main.ts",
+    "start:dev": "npx prisma generate && ts-node src/main.ts",
     "start:debug": "ts-node --inspect-brk src/main.ts",
     "start:prod": "node dist/main.js",
     "test": "jest",

--- a/services/posts/package.json
+++ b/services/posts/package.json
@@ -4,10 +4,10 @@
   "description": "Posts microservice for CRUNEVO social network",
   "main": "dist/main.js",
   "scripts": {
-    "build": "nest build",
+    "build": "prisma generate && nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
-    "start:dev": "nest start --watch",
+    "start:dev": "prisma generate && nest start --watch",
     "start:debug": "nest start --debug --watch",
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",


### PR DESCRIPTION
## Summary
- ensure each service generates Prisma client before starting or building
- document automated Prisma generation in README

## Testing
- `npm run build` (identity)
- `npm run build` (posts)
- `npm run build` (messages)
- `npm test` (identity)
- `npm test` (posts) *(fails: No tests found)*
- `npm test` (messages) *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bb3d9c448321b010999d1f28970e